### PR TITLE
[Rakefile] Introduce tasks to run specs and generate fixtures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-script: scripts/travis.sh
+script: bundle exec rake
 
 # Sets Travis to run the Ruby specs on OS X machines which are required to
 # build the native extensions of Xcodeproj.

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,14 @@
 require "bundler/gem_tasks"
 
+desc "Generate the test fixtures"
+task :generate_fixtures do
+  sh "xcodebuild -project spec/fixtures/fixtures.xcodeproj/ -scheme fixtures -configuration Debug test"
+end
+
+desc "Run all the specs"
+task :specs do
+  sh "rspec"
+end
+
+task :default => [:generate_fixtures, :specs]
+

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,2 +1,0 @@
-xcodebuild -project spec/fixtures/fixtures.xcodeproj/ -scheme fixtures -configuration Debug test
-bundle exec rspec


### PR DESCRIPTION
To get the tests running locally, you currently need to figure out how travis is doing it and manually invoke a command to generate the test fixtures. To make this a bit easier, I've moved the logic into the Rakefile so you can run `bundle exec rake` to generate the fixtures and run the specs.

``` bash
$ bundle exec rake -T
rake build              # Build slather-1.0.1.gem into the pkg directory
rake generate_fixtures  # Generate the test fixtures
rake install            # Build and install slather-1.0.1.gem into system gems
rake release            # Create tag v1.0.1 and build and push slather-1.0.1.gem to Rubygems
rake specs              # Run all the specs
```
