### PR TITLE
Fix typo in README

### DIFF
--- a/bin/slather
+++ b/bin/slather
@@ -7,7 +7,7 @@ Clamp do
 
   self.default_subcommand = "coverage"
 
-  subcommand "coverage", "Computes coverage for the supplised project" do
+  subcommand "coverage", "Computes coverage for the supplied project" do
 
     parameter "[xcodeproj]", "Path to the xcodeproj", :attribute_name => :xcodeproj_path
 


### PR DESCRIPTION
Sup, me again. While I'm here... shouldn't the description for `--simple-output` be different from the description for `--coveralls`?
