### PR TITLE
Updating link to build directory example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ source_directory: Pods/AFNetworking
 
 ### Custom Build Directory
 
-Slather will look for the test coverage files in `DerivedData` by default. If you send build output to a custom location, like [this](https://github.com/erikdoe/ocmock/blob/master/Tools/travis.sh#L12), then you should also set the `build_directory` property in `.slather.yml`
+Slather will look for the test coverage files in `DerivedData` by default. If you send build output to a custom location, like [this](https://github.com/erikdoe/ocmock/blob/7f4d22b38eedf1bb9a12ab1591ac0a5d436db61a/Tools/travis.sh#L12), then you should also set the `build_directory` property in `.slather.yml`
 
 ## Contributing
 


### PR DESCRIPTION
So it looks like [OCMock moved from build scripts to a Makefile](https://github.com/erikdoe/ocmock/commit/15b251147255180559d121dc1a1c04f27a2123e8), so the link to the custom build location example broke, since it linked to `master`. In lieu of having to grep through their Makefile to figure out how they use build directories, just link to the absolute reference to their old build script!

:octocat: 
