### PR TITLE
Add `binary_basename` configuration option

### DIFF
--- a/bin/slather
+++ b/bin/slather
@@ -32,6 +32,7 @@ Clamp do
     option ["--input-format"], "INPUT_FORMAT", "Input format (gcov, profdata)"
     option ["--scheme"], "SCHEME", "The scheme for which the coverage was generated"
     option ["--binary-file"], "BINARY_FILE", "The binary file against the which the coverage will be run"
+    option ["--binary-basename"], "BINARY_BASENAME", "Basename of the file against which the coverage will be run"
 
     def execute
       puts "Slathering..."
@@ -46,6 +47,7 @@ Clamp do
       setup_input_format
       setup_scheme
       setup_binary_file
+      setup_binary_basename
 
       project.configure
 
@@ -126,6 +128,10 @@ Clamp do
 
     def setup_binary_file
       project.binary_file = binary_file
+    end
+
+    def setup_binary_basename
+      project.binary_basename = binary_basename
     end
 
   end

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -278,9 +278,10 @@ module Slather
       raise StandardError, "No product binary found in #{profdata_coverage_dir}. Are you sure your project is setup for generating coverage files? Try `slather setup your/project.xcodeproj`" unless xctest_bundle != nil
 
       # Find the matching binary file
+      search_for = self.class.yml["binary_basename"] || '*'
       xctest_bundle_file_directory = Pathname.new(xctest_bundle).dirname
-      app_bundle = Dir["#{xctest_bundle_file_directory}/*.app"].first
-      dynamic_lib_bundle = Dir["#{xctest_bundle_file_directory}/*.framework"].first
+      app_bundle = Dir["#{xctest_bundle_file_directory}/#{search_for}.app"].first
+      dynamic_lib_bundle = Dir["#{xctest_bundle_file_directory}/#{search_for}.framework"].first
 
       if app_bundle != nil
         find_binary_file_for_app(app_bundle)

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -51,7 +51,7 @@ module Slather
   class Project < Xcodeproj::Project
 
     attr_accessor :build_directory, :ignore_list, :ci_service, :coverage_service, :coverage_access_token, :source_directory, 
-      :output_directory, :xcodeproj, :show_html, :verbose_mode, :input_format, :scheme, :binary_file
+      :output_directory, :xcodeproj, :show_html, :verbose_mode, :input_format, :scheme, :binary_file, :binary_basename
 
     alias_method :setup_for_coverage, :slather_setup_for_coverage
 
@@ -278,7 +278,7 @@ module Slather
       raise StandardError, "No product binary found in #{profdata_coverage_dir}. Are you sure your project is setup for generating coverage files? Try `slather setup your/project.xcodeproj`" unless xctest_bundle != nil
 
       # Find the matching binary file
-      search_for = self.class.yml["binary_basename"] || '*'
+      search_for = self.binary_basename || self.class.yml["binary_basename"] || '*'
       xctest_bundle_file_directory = Pathname.new(xctest_bundle).dirname
       app_bundle = Dir["#{xctest_bundle_file_directory}/#{search_for}.app"].first
       dynamic_lib_bundle = Dir["#{xctest_bundle_file_directory}/#{search_for}.framework"].first

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -182,6 +182,21 @@ describe Slather::Project do
       expect(binary_file_location).to eq("/FixtureScheme/From/Yaml/Contents/MacOS/FixturesFromYaml")
     end
 
+    let(:other_fixture_yaml) do
+      yaml_text = <<-EOF
+        binary_basename: "FixtureFramework"
+      EOF
+      yaml = YAML.load(yaml_text)
+    end
+
+    it "should configure the binary_basename from yml" do
+      Slather::Project.stub(:yml).and_return(other_fixture_yaml)
+      Dir.stub(:[]).with("#{build_directory}/Build/Intermediates/CodeCoverage/FixtureScheme/FixtureFramework.framework").and_return(["/FixtureScheme/FixtureFramework.framework"])
+      fixtures_project.send(:configure_binary_file)
+      binary_file_location = fixtures_project.send(:binary_file)
+      expect(binary_file_location).to eq("/FixtureScheme/FixtureFramework.framework/FixtureFramework")
+    end
+
  #  it "should find the binary file without any yml setting" do
  #    fixtures_project.configure_binary_file
  #    Dir.stub(:[]).with("#{build_directory}/Build/Intermediates/CodeCoverage/FixtureScheme/*.app").and_return(["/FixtureScheme/FixtureApp.app"])


### PR DESCRIPTION
Makes it easier to select the right binary to consider for code coverage computation. Instead of having to pass the full path to your framework, you can just configure its basename and it will be found :sparkles: