### PR TITLE
Making HTML directory self contained

### DIFF
--- a/lib/slather/coverage_service/html_output.rb
+++ b/lib/slather/coverage_service/html_output.rb
@@ -50,6 +50,11 @@ module Slather
         FileUtils.rm_rf(directory_path) if Dir.exist?(directory_path)
         FileUtils.mkdir_p(directory_path)
 
+        FileUtils.cp(File.join(gem_root_path, "docs/logo.jpg"), directory_path)
+        FileUtils.cp(File.join(gem_root_path, "assets/slather.css"), directory_path)
+        FileUtils.cp(File.join(gem_root_path, "assets/highlight.pack.js"), directory_path)
+        FileUtils.cp(File.join(gem_root_path, "assets/list.min.js"), directory_path)
+
         reports.each do |name, doc|
           html_file = File.join(directory_path, "#{name}.html")
           File.write(html_file, doc.to_html)
@@ -177,10 +182,10 @@ module Slather
       end
 
       def generate_html_template(title, is_index, is_file_empty)
-        logo_path = File.join(gem_root_path, "docs/logo.jpg")
-        css_path = File.join(gem_root_path, "assets/slather.css")
-        highlight_js_path = File.join(gem_root_path, "assets/highlight.pack.js")
-        list_js_path = File.join(gem_root_path, "assets/list.min.js")
+        logo_path = "logo.jpg"
+        css_path = "slather.css"
+        highlight_js_path = "highlight.pack.js"
+        list_js_path = "list.min.js"
 
         builder = Nokogiri::HTML::Builder.new do |doc|
           doc.html {


### PR DESCRIPTION
I took a pull request by @joshrlesch, and cleaned it up so it didn't add anything custom back in. Tested on our own CI Servers.

This copies all the resources necessary to render the HTML into the HTML directory. We need something like this so we can upload the HTML to a web server where other users can view it.

I amended his commit. It looks like it has a different id, so it shouldn't cause any conflicts even though I was mucking with Git history.