### PR TITLE
Avoid specifying path for bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_install:
   - if [[ $RVM_RUBY_VERSION == 'system' ]]; then sudo gem install bundler --no-ri --no-rdoc; else gem install bundler --no-ri --no-rdoc; fi
 
 install:
-  - bundle install --without=documentation --path ./travis_bundle_dir
+  - bundle install --without=documentation


### PR DESCRIPTION
This tries to fix wrong coverage report for this gem itself by avoiding bundle gem source being counted in Coveralls.

https://coveralls.io/github/SlatherOrg/slather