### PR TITLE
Fixes how profdata_coverage_dir is created.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Fixes how `profdata_coverage_dir` is created.
+  [guidomb](https://github.com/guidomb)
+  [#145](https://github.com/SlatherOrg/slather/pull/145)
+
 ## v2.0.0
 * Correct html rendering when using profdata format   
   [cutz](https://github.com/cutz)

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -50,7 +50,7 @@ end
 module Slather
   class Project < Xcodeproj::Project
 
-    attr_accessor :build_directory, :ignore_list, :ci_service, :coverage_service, :coverage_access_token, :source_directory, 
+    attr_accessor :build_directory, :ignore_list, :ci_service, :coverage_service, :coverage_access_token, :source_directory,
       :output_directory, :xcodeproj, :show_html, :verbose_mode, :input_format, :scheme, :binary_file, :binary_basename
 
     alias_method :setup_for_coverage, :slather_setup_for_coverage
@@ -100,13 +100,24 @@ module Slather
     end
     private :profdata_coverage_files
 
+    def remove_extension(path)
+      path.split(".")[0..-2].join(".")
+    end
+
+    def first_product_name
+      first_product = self.products.first
+      # If name is not available it computes it using
+      # the path by dropping the 'extension' of the path.
+      first_product.name || remove_extension(first_product.path)
+    end
+
     def profdata_coverage_dir
       raise StandardError, "The specified build directory (#{self.build_directory}) does not exist" unless File.exists?(self.build_directory)
       dir = nil
       if self.scheme
-        dir = Dir["#{build_directory}/**/CodeCoverage/#{self.scheme}"].first
+        dir = Dir[File.join("#{build_directory}","/**/CodeCoverage/#{self.scheme}")].first
       else
-        dir = Dir["#{build_directory}/**/#{self.products.first.name}"].first
+        dir = Dir[File.join("#{build_directory}","/**/#{first_product_name}")].first
       end
 
       raise StandardError, "No coverage directory found. Are you sure your project is setup for generating coverage files? Try `slather setup your/project.xcodeproj`" unless dir != nil

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -375,13 +375,13 @@ describe Slather::Project do
       expect(fixtures_project).to receive(:coverage_access_token=).with("abc123")
       fixtures_project.configure_coverage_access_token
     end
-    
+
     it "should set the coverage_access_token if it is in the ENV" do
       stub_const('ENV', ENV.to_hash.merge('COVERAGE_ACCESS_TOKEN' => 'asdf456'))
       expect(fixtures_project).to receive(:coverage_access_token=).with("asdf456")
       fixtures_project.configure_coverage_access_token
     end
-    
+
   end
 
   describe "#coverage_service=" do
@@ -449,8 +449,8 @@ describe Slather::Project do
 
       project_root = Pathname("./").realpath
 
-      ["\nProcessing coverage file: #{project_root}/spec/DerivedData/Build/Intermediates/CodeCoverage/fixtures/Coverage.profdata",
-       "Against binary file: #{project_root}/spec/DerivedData/Build/Intermediates/CodeCoverage/fixtures/Products/Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests\n\n"
+      ["\nProcessing coverage file: #{project_root}/spec/DerivedData/libfixtures/Build/Intermediates/CodeCoverage/fixtures/Coverage.profdata",
+       "Against binary file: #{project_root}/spec/DerivedData/libfixtures/Build/Intermediates/CodeCoverage/fixtures/Products/Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests\n\n"
       ].each do |line|
         expect(fixtures_project).to receive(:puts).with(line)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,8 @@ FIXTURES_JSON_PATH = File.join(File.dirname(__FILE__), 'fixtures/gutter.json')
 FIXTURES_HTML_FOLDER_PATH = File.join(File.dirname(__FILE__), 'fixtures/fixtures_html')
 FIXTURES_PROJECT_PATH = File.join(File.dirname(__FILE__), 'fixtures/fixtures.xcodeproj')
 FIXTURES_SWIFT_FILE_PATH = File.join(File.dirname(__FILE__), 'fixtures/fixtures/Fixtures.swift')
-TEMP_DERIVED_DATA_PATH = File.join(File.dirname(__FILE__), 'DerivedData/')
+TEMP_DERIVED_DATA_PATH = File.join(File.dirname(__FILE__), 'DerivedData')
+TEMP_PROJECT_BUILD_PATH = File.join(TEMP_DERIVED_DATA_PATH, "libfixtures")
 TEMP_OBJC_GCNO_PATH = File.join(File.dirname(__FILE__), 'fixtures/ObjectiveC.gcno')
 TEMP_OBJC_GCDA_PATH = File.join(File.dirname(__FILE__), 'fixtures/ObjectiveC.gcda')
 
@@ -39,7 +40,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     FixtureHelpers.delete_derived_data
     FixtureHelpers.delete_temp_gcov_files
-    `xcodebuild -project "#{FIXTURES_PROJECT_PATH}" -scheme fixtures -configuration Debug -derivedDataPath #{File.join(TEMP_DERIVED_DATA_PATH, "libfixtures")} -enableCodeCoverage YES clean test`
+    `xcodebuild -project "#{FIXTURES_PROJECT_PATH}" -scheme fixtures -configuration Debug -derivedDataPath #{TEMP_PROJECT_BUILD_PATH} -enableCodeCoverage YES clean test`
   end
 
   config.after(:suite) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     FixtureHelpers.delete_derived_data
     FixtureHelpers.delete_temp_gcov_files
-    `xcodebuild -project "#{FIXTURES_PROJECT_PATH}" -scheme fixtures -configuration Debug -derivedDataPath #{TEMP_DERIVED_DATA_PATH} -enableCodeCoverage YES clean test`
+    `xcodebuild -project "#{FIXTURES_PROJECT_PATH}" -scheme fixtures -configuration Debug -derivedDataPath #{File.join(TEMP_DERIVED_DATA_PATH, "libfixtures")} -enableCodeCoverage YES clean test`
   end
 
   config.after(:suite) do


### PR DESCRIPTION
Version `2.0.0` of this gem fails with the following error in my project

```
Slathering...
error: Failed to load coverage: No object file for requested architecture
Test Coverage: NaN%
Slathered
```
running with verbose flag generated the following output

```
Slathering...

Processing coverage file: /Users/guidomb/Library/Developer/Xcode/DerivedData/Syrmo-gaycqmnmsbrteuaehthyregbeoec/Build/Intermediates/CodeCoverage/Syrmo/Coverage.profdata
Against binary file: /Users/guidomb/Library/Developer/Xcode/DerivedData/RESideMenu-drntsirbvffjqvdnxrvriljshzty/Build/Products/Release-iphoneos/RESideMenu.framework/RESideMenu

error: Failed to load coverage: No object file for requested architecture
Test Coverage: NaN%
Slathered
```

As it can be seen the binary file was pointing to another project (a dependency of my project, Syrmo, to be precise). After some debugging I found that the cause of this error was related with how `profdata_coverage_dir` was created.