### PR TITLE
Profdata Coverage only for files in the specified source directory

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -93,10 +93,13 @@ module Slather
     def profdata_coverage_files
       files = profdata_llvm_cov_output.split("\n\n")
 
-      files.map do |source|
+      files = files.map do |source|
         coverage_file = coverage_file_class.new(self, source)
         !coverage_file.ignored? ? coverage_file : nil
       end.compact
+      
+      absolute_source_directory = File.expand_path(source_directory)
+      files.select { |file| file.source_file_pathname.to_s.start_with?(absolute_source_directory) }
     end
     private :profdata_coverage_files
 

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -98,8 +98,12 @@ module Slather
         !coverage_file.ignored? ? coverage_file : nil
       end.compact
       
-      absolute_source_directory = File.expand_path(source_directory)
-      files.select { |file| file.source_file_pathname.to_s.start_with?(absolute_source_directory) }
+      if source_directory
+        absolute_source_directory = File.expand_path(source_directory)
+        files = files.select { |file| file.source_file_pathname.to_s.start_with?(absolute_source_directory) }
+      end
+
+      files
     end
     private :profdata_coverage_files
 


### PR DESCRIPTION
 The change is to only produces code coverage for the files specified in the source directory. This becomes particularly useful when running slather on a Pods project with dependencies which you don't want included in the coverage report.