### PR TITLE
Add date dependency

### DIFF
--- a/lib/slather/coverage_service/cobertura_xml_output.rb
+++ b/lib/slather/coverage_service/cobertura_xml_output.rb
@@ -1,4 +1,5 @@
 require 'nokogiri'
+require 'date'
 
 module Slather
   module CoverageService


### PR DESCRIPTION
I had to add the date dependency in order to make it work. Without I get:

    <..>/cobertura_xml_output.rb:114:in `create_xml_report': uninitialized constant Slather::CoverageService::CoberturaXmlOutput::DateTime (NameError)

Call command was:

    slather coverage --jenkins -x --output-directory .  MyProject.xcodeproj