### PR TITLE
Build Statistic Reporting for TeamCity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ cobertura.xml
 html
 *.gcda
 *.gcno
+
+# JetBrains IDE
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ## master
+* Build Statistic Reporting for TeamCity
+  [Michael Myers](https://github.com/michaelmyers)
+  [#150](https://github.com/SlatherOrg/slather/pull/150)
 
 ## v2.0.0
 * Correct html rendering when using profdata format   

--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ $ slather coverage --html path/to/project.xcodeproj
 
 This will make a directory named `html` in your root directory (unless `--output-directory` is specified) and will generate all the reports as static html pages inside the directory. It will print out the report's path by default, but you can also specify `--show` flag to open it in your browser automatically.
 
+### TeamCity Reporting
+
+To report the coverage statistics to TeamCity:
+
+```sh
+$ slather coverage --teamcity -s
+```
+
 ### Coverage for code included via CocoaPods
 
 If you're trying to compute the coverage of code that has been included via

--- a/bin/slather
+++ b/bin/slather
@@ -15,6 +15,7 @@ Clamp do
     option ["--circleci"], :flag, "Indicate that the builds are running on CircleCI"
     option ["--jenkins"], :flag, "Indicate that the builds are running on Jenkins"
     option ["--buildkite"], :flag, "Indicate that the builds are running on Buildkite"
+    option ["--teamcity"], :flag, "Indicate that the builds are running on TeamCity"
 
     option ["--coveralls", "-c"], :flag, "Post coverage results to coveralls"
     option ["--simple-output", "-s"], :flag, "Output coverage results to the terminal"
@@ -81,6 +82,8 @@ Clamp do
         project.ci_service = :jenkins
       elsif buildkite?
         project.ci_service = :buildkite
+      elsif teamcity?
+        project.ci_service = :teamcity
       end
     end
 

--- a/lib/slather/coverage_service/simple_output.rb
+++ b/lib/slather/coverage_service/simple_output.rb
@@ -26,6 +26,22 @@ module Slather
 
           puts "#{coverage_file.source_file_pathname_relative_to_repo_root}: #{lines_tested} of #{total_lines} lines (#{percentage}%)"
         end
+
+        # check if there needs to be custom reporting based on the ci service
+        if ci_service == :teamcity
+          # TeamCity Build Statistic Reporting
+          #
+          # Reporting format ##teamcity[buildStatisticValue key='<valueTypeKey>' value='<value>']
+          # key='CodeCoverageAbsLCovered' is total number of lines covered
+          # key='CodeCoverageAbsLTotal' is total number of lines
+          #
+          # Sources:
+          # - https://confluence.jetbrains.com/display/TCDL/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingBuildStatistics
+          # - https://confluence.jetbrains.com/display/TCDL/Custom+Chart#CustomChart-listOfDefaultStatisticValues
+          puts "##teamcity[buildStatisticValue key='CodeCoverageAbsLCovered' value='%i']" % total_project_lines_tested
+          puts "##teamcity[buildStatisticValue key='CodeCoverageAbsLTotal' value='%i']" % total_project_lines
+        end
+
         total_percentage = '%.2f' % [(total_project_lines_tested / total_project_lines.to_f) * 100.0]
         puts "Test Coverage: #{total_percentage}%"
       end

--- a/spec/slather/coverage_service/simple_output_spec.rb
+++ b/spec/slather/coverage_service/simple_output_spec.rb
@@ -6,7 +6,7 @@ describe Slather::CoverageService::SimpleOutput do
     proj = Slather::Project.open(FIXTURES_PROJECT_PATH)
     proj.build_directory = TEMP_DERIVED_DATA_PATH
     proj.input_format = "profdata"
-    proj.send(:configure)
+    proj.configure
     proj
   end
 

--- a/spec/slather/coverage_service/simple_output_spec.rb
+++ b/spec/slather/coverage_service/simple_output_spec.rb
@@ -6,7 +6,7 @@ describe Slather::CoverageService::SimpleOutput do
     proj = Slather::Project.open(FIXTURES_PROJECT_PATH)
     proj.build_directory = TEMP_DERIVED_DATA_PATH
     proj.input_format = "profdata"
-    proj.configure
+    proj.send(:configure)
     proj
   end
 
@@ -30,5 +30,30 @@ describe Slather::CoverageService::SimpleOutput do
 
       fixtures_project.post
     end
+
+    describe 'ci_service reporting output' do
+
+      context "ci_service is :teamcity" do
+        before(:each) { fixtures_project.ci_service = :teamcity }
+
+        it "should print out the coverage" do
+          ["spec/fixtures/fixtures/fixtures.m: 3 of 6 lines (50.00%)",
+           "spec/fixtures/fixtures/more_files/Branches.m: 13 of 30 lines (43.33%)",
+           "spec/fixtures/fixturesTests/BranchesTests.m: 16 of 16 lines (100.00%)",
+           "spec/fixtures/fixturesTests/fixturesTests.m: 12 of 12 lines (100.00%)",
+           "spec/fixtures/fixturesTests/peekaviewTests.m: 11 of 11 lines (100.00%)",
+           "##teamcity[buildStatisticValue key='CodeCoverageAbsLCovered' value='55']",
+           "##teamcity[buildStatisticValue key='CodeCoverageAbsLTotal' value='75']",
+           "Test Coverage: 73.33%"
+          ].each do |line|
+            expect(fixtures_project).to receive(:puts).with(line)
+          end
+
+          fixtures_project.post
+        end
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
This adds the flag `--teamcity` and then within the `simple_output` coverage service it leverages the [default build statistics for coverage](https://confluence.jetbrains.com/display/TCDL/Custom+Chart#CustomChart-listOfDefaultStatisticValues) to [report](https://confluence.jetbrains.com/display/TCDL/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingBuildStatistics) the results to TeamCity, a continuous integration server by JetBrains.

Example usage would be:

```sh
$ slather coverage --teamcity -s
```

We also can consider cherry-picking [joshrlesch's commit](https://github.com/hudl/slather/commit/4a101fdd315f41aa4ad80289230d7ef04ffc2965) from [PR 132](https://github.com/SlatherOrg/slather/pull/132) which adds support for TeamCity within the `coverall` coverage service to complete the solution.   

This is my first time with ruby so I am looking forward to feedback. 