### PR TITLE
Fix for not being able to find some xctest bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 ## master
+* Improve matching of xctest bundles when using `--binary-basename`
+  [Kent Sutherland](https://github.com/ksuther)
+  [#167](https://github.com/SlatherOrg/slather/pull/167)
+
 * Build Statistic Reporting for TeamCity
   [Michael Myers](https://github.com/michaelmyers)
   [#150](https://github.com/SlatherOrg/slather/pull/150)

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -294,6 +294,7 @@ module Slather
       xctest_bundle_file_directory = Pathname.new(xctest_bundle).dirname
       app_bundle = Dir["#{xctest_bundle_file_directory}/#{search_for}.app"].first
       dynamic_lib_bundle = Dir["#{xctest_bundle_file_directory}/#{search_for}.framework"].first
+      xctest_bundle = Dir["#{xctest_bundle_file_directory}/#{search_for}.xctest"].first
 
       if app_bundle != nil
         find_binary_file_for_app(app_bundle)

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -294,12 +294,14 @@ module Slather
       xctest_bundle_file_directory = Pathname.new(xctest_bundle).dirname
       app_bundle = Dir["#{xctest_bundle_file_directory}/#{search_for}.app"].first
       dynamic_lib_bundle = Dir["#{xctest_bundle_file_directory}/#{search_for}.framework"].first
-      xctest_bundle = Dir["#{xctest_bundle_file_directory}/#{search_for}.xctest"].first
+      matched_xctest_bundle = Dir["#{xctest_bundle_file_directory}/#{search_for}.xctest"].first
 
       if app_bundle != nil
         find_binary_file_for_app(app_bundle)
       elsif dynamic_lib_bundle != nil
         find_binary_file_for_dynamic_lib(dynamic_lib_bundle)
+      elsif matched_xctest_bundle != nil
+        find_binary_file_for_static_lib(matched_xctest_bundle)
       else
         find_binary_file_for_static_lib(xctest_bundle)
       end


### PR DESCRIPTION
Update xctest_bundle using the search_for variable. Before xctest_bundle would be set to the first xctest bundle in the build products, even if we're searching for a different test target.

For example, a command such as:

slather coverage --scheme MyScheme --binary-basename BTests --html MyProject.xcodeproj

Would pick ATests over BTests if there are test targets for ATests and BTests, because ATests would always be the first path returned in the initial assignment.