### PR TITLE
Updated profdata_coverage_dir to work with Xcode 7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 ## master
+* Xcode 7.3 compatibility (updated path returned by `profdata_coverage_dir`)
+  [Kent Sutherland](https://github.com/ksuther)
+  [#125](https://github.com/SlatherOrg/slather/issues/125), [#169](https://github.com/SlatherOrg/slather/pull/169)
+
 * Improve matching of xctest bundles when using `--binary-basename`
   [Kent Sutherland](https://github.com/ksuther)
   [#167](https://github.com/SlatherOrg/slather/pull/167)

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -120,6 +120,11 @@ module Slather
         dir = Dir[File.join("#{build_directory}","/**/#{first_product_name}")].first
       end
 
+      if dir == nil
+        # Xcode 7.3 moved the location of Coverage.profdata
+        dir = Dir[File.join("#{build_directory}","/**/CodeCoverage")].first
+      end
+
       raise StandardError, "No coverage directory found. Are you sure your project is setup for generating coverage files? Try `slather setup your/project.xcodeproj`" unless dir != nil
       dir
     end


### PR DESCRIPTION
This fixes #125. profdata_coverage_dir first tries the Xcode 7.2.1 paths, then falls back to the new Xcode 7.3 path if the 7.2.1 path isn't found.

I did not update the tests in `project_spec.rb`. The expected output on lines 452 and 453 will need to be updated when the CI is moved up to Xcode 7.3.