### PR TITLE
Workspace support and better error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master
 
+* Support for Xcode workspaces. Define `workspace` configuration in `.slather.yml` or use the `--workspace` argument if you build in a workspace.  
+* Improved slather error messages  
+  [Kent Sutherland](https://github.com/ksuther)
+  [#178](https://github.com/SlatherOrg/slather/issues/178)
+
 * Re-add Teamcity support  
   [Boris Bügling](https://github.com/neonichu)
   [#180](https://github.com/SlatherOrg/slather/pull/180)

--- a/README.md
+++ b/README.md
@@ -31,27 +31,37 @@ And then execute:
 $ bundle
 ```
 
+Or install the gem:
+
+```sh
+gem install slather
+```
+
 ## Usage
 
-Apple drastically improved the support for code coverage in Xcode 7, including dedicated UI for enabling it. You can now setup your project for test coverage inside the scheme editor, by ticking the *"Gather coverage data"* checkbox:
+Enable test coverage by ticking the *"Gather coverage data"* checkbox when editing a scheme:
 
 ![](README_Images/test_scheme.png)
 
 To verify you're ready to generate test coverage, run your test suite on your project, and then run:
 
 ```sh
-$ slather coverage -s path/to/project.xcodeproj
+$ slather coverage -s --scheme YourXcodeSchemeName path/to/project.xcodeproj
 ```
 
-### Previous versions of Xcode
+If you use a workspace in Xcode you need to specify it: 
 
-Set up your project for test coverage:
+```sh
+$ slather coverage -s --scheme YourXcodeSchemeName --workspace path/to/workspace.xcworkspace path/to/project.xcodeproj
+```
+
+### Setup for Xode 5 and 6
+
+Run this command to enable the `Generate Test Coverage` and `Instrument Program Flow` flags for your project:
 
 ```sh
 $ slather setup path/to/project.xcodeproj
 ```
-
-This will enable the `Generate Test Coverage` and `Instrument Program Flow` flags for your project.
 
 ### Usage with Codecov
 
@@ -64,6 +74,7 @@ Make a `.slather.yml` file:
 
 coverage_service: cobertura_xml
 xcodeproj: path/to/project.xcodeproj
+scheme: YourXcodeSchemeName
 source_directory: path/to/sources/to/include
 output_directory: path/to/xml_report
 ignore:
@@ -105,6 +116,7 @@ Make a `.slather.yml` file:
 
 coverage_service: coveralls
 xcodeproj: path/to/project.xcodeproj
+scheme: YourXcodeSchemeName
 ignore:
   - ExamplePodCode/*
   - ProjectTestsGroup/*
@@ -151,6 +163,7 @@ To create a Cobertura XML report set `cobertura_xml` as coverage service inside 
 
 coverage_service: cobertura_xml
 xcodeproj: path/to/project.xcodeproj
+scheme: YourXcodeSchemeName
 source_directory: path/to/sources/to/include
 output_directory: path/to/xml_report
 ignore:
@@ -169,7 +182,7 @@ $ slather coverage -x --output-directory path/to/xml_report
 To create a report as static html pages, use the command line options `--html`:
 
 ```sh
-$ slather coverage --html path/to/project.xcodeproj
+$ slather coverage --html --scheme YourXcodeSchemeName path/to/project.xcodeproj
 ```
 
 This will make a directory named `html` in your root directory (unless `--output-directory` is specified) and will generate all the reports as static html pages inside the directory. It will print out the report's path by default, but you can also specify `--show` flag to open it in your browser automatically.
@@ -179,7 +192,7 @@ This will make a directory named `html` in your root directory (unless `--output
 To report the coverage statistics to TeamCity:
 
 ```sh
-$ slather coverage --teamcity -s
+$ slather coverage --teamcity -s --scheme YourXcodeSchemeName
 ```
 
 ### Coverage for code included via CocoaPods
@@ -203,6 +216,14 @@ source_directory: Pods/AFNetworking
 ### Custom Build Directory
 
 Slather will look for the test coverage files in `DerivedData` by default. If you send build output to a custom location, like [this](https://github.com/erikdoe/ocmock/blob/7f4d22b38eedf1bb9a12ab1591ac0a5d436db61a/Tools/travis.sh#L12), then you should also set the `build_directory` property in `.slather.yml`
+
+### Building in a workspace
+
+Include the `--workspace` argument or add `workspace` to `.slather.yml` if you build your project in a workspace. For example:
+
+```sh
+$ slather coverage --html --scheme YourXcodeSchemeName --workspace path/to/workspace.xcworkspace path/to/project.xcodeproj
+```
 
 ## Contributing
 

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -23,6 +23,7 @@ class CoverageCommand < Clamp::Command
 
   option ["--input-format"], "INPUT_FORMAT", "Input format (gcov, profdata)"
   option ["--scheme"], "SCHEME", "The scheme for which the coverage was generated"
+  option ["--workspace"], "WORKSPACE", "The workspace that the project was built in"
   option ["--binary-file"], "BINARY_FILE", "The binary file against the which the coverage will be run"
   option ["--binary-basename"], "BINARY_BASENAME", "Basename of the file against which the coverage will be run"
 
@@ -38,6 +39,7 @@ class CoverageCommand < Clamp::Command
     setup_verbose_mode
     setup_input_format
     setup_scheme
+    setup_workspace
     setup_binary_file
     setup_binary_basename
 
@@ -118,6 +120,10 @@ class CoverageCommand < Clamp::Command
 
   def setup_scheme
     project.scheme = scheme
+  end
+
+  def setup_workspace
+    project.workspace = workspace
   end
 
   def setup_binary_file

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -320,6 +320,12 @@ module Slather
         xcscheme = Xcodeproj::XCScheme.new(xcscheme_path)
 
         buildable_name = xcscheme.build_action.entries[0].buildable_references[0].buildable_name
+
+        if buildable_name.end_with? ".a"
+          # Can't run code coverage on static libraries, look for an associated test bundle
+          buildable_name = xcscheme.test_action.testables[0].buildable_references[0].buildable_name
+        end
+
         configuration = xcscheme.test_action.build_configuration
 
         search_for = binary_basename || buildable_name

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -62,7 +62,7 @@ module Slather
     end
 
     def failure_help_string
-      "\n\tAre you sure your project is generating coverage? Try `slather setup your/project.xcodeproj`.\n\tDid you specify your Xcode scheme? (--scheme or 'scheme' in .slather.yml)\n\tIf you're using a workspace, did you specify it? (--workspace or 'workspace' in .slather.yml)"
+      "\n\tAre you sure your project is generating coverage? Make sure you enable code coverage in the Test section of your Xcode scheme.\n\tDid you specify your Xcode scheme? (--scheme or 'scheme' in .slather.yml)\n\tIf you're using a workspace, did you specify it? (--workspace or 'workspace' in .slather.yml)"
     end
 
     def derived_data_path

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -314,6 +314,9 @@ module Slather
       if self.scheme
         schemes_path = Xcodeproj::XCScheme.shared_data_dir(self.path)
         xcscheme_path = "#{schemes_path + self.scheme}.xcscheme"
+
+        raise StandardError, "No shared scheme named '#{self.scheme}' found in #{self.path}" unless File.exists? xcscheme_path
+
         xcscheme = Xcodeproj::XCScheme.new(xcscheme_path)
 
         buildable_name = xcscheme.build_action.entries[0].buildable_references[0].buildable_name

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -61,6 +61,10 @@ module Slather
       proj
     end
 
+    def failure_help_string
+      "\n\tAre you sure your project is generating coverage? Try `slather setup your/project.xcodeproj`.\n\tDid you specify your Xcode scheme? (--scheme or 'scheme' in .slather.yml)\n\tIf you're using a workspace, did you specify it? (--workspace or 'workspace' in .slather.yml)"
+    end
+
     def derived_data_path
       # Get the derived data path from xcodebuild
       # Use OBJROOT when possible, as it provides regardless of whether or not the Derived Data location is customized
@@ -107,7 +111,7 @@ module Slather
       end.compact
 
       if coverage_files.empty?
-        raise StandardError, "No coverage files found. Are you sure your project is setup for generating coverage files? Try `slather setup your/project.xcodeproj`"
+        raise StandardError, "No coverage files found."
       else
         dedupe(coverage_files)
       end
@@ -149,7 +153,7 @@ module Slather
         dir = Dir[File.join("#{build_directory}","/**/CodeCoverage")].first
       end
 
-      raise StandardError, "No coverage directory found. Are you sure your project is setup for generating coverage files? Try `slather setup your/project.xcodeproj`" unless dir != nil
+      raise StandardError, "No coverage directory found." unless dir != nil
       dir
     end
 
@@ -201,17 +205,24 @@ module Slather
     end
 
     def configure
-      configure_build_directory
-      configure_ignore_list
-      configure_ci_service
-      configure_coverage_access_token
-      configure_coverage_service
-      configure_source_directory
-      configure_output_directory
-      configure_input_format
-      configure_scheme
-      configure_workspace
-      configure_binary_file
+      begin
+        configure_build_directory
+        configure_ignore_list
+        configure_ci_service
+        configure_coverage_access_token
+        configure_coverage_service
+        configure_source_directory
+        configure_output_directory
+        configure_input_format
+        configure_scheme
+        configure_workspace
+        configure_binary_file
+      rescue => e
+        puts e.message
+        puts failure_help_string
+        puts "\n"
+        raise
+      end
 
       if self.verbose_mode
         puts "\nProcessing coverage file: #{profdata_file}"
@@ -366,10 +377,9 @@ module Slather
         end
       end
 
-      raise StandardError, "No product binary found in #{profdata_coverage_dir}. Are you sure your project is setup for generating coverage files? Try `slather setup your/project.xcodeproj`" unless found_binary != nil
+      raise StandardError, "No product binary found in #{profdata_coverage_dir}." unless found_binary != nil
 
       found_binary
     end
-
   end
 end

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "simplecov"
   spec.add_development_dependency "rake", "~> 10.4"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "pry", "~> 0.9"

--- a/spec/fixtures/fixtures.xcodeproj/xcshareddata/xcschemes/fixtures.xcscheme
+++ b/spec/fixtures/fixtures.xcodeproj/xcshareddata/xcschemes/fixtures.xcscheme
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,24 +39,36 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8C9A202C195965F10013B6B3"
+            BuildableName = "libfixtures.a"
+            BlueprintName = "fixtures"
+            ReferencedContainer = "container:fixtures.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/spec/fixtures/fixtures.xcodeproj/xcshareddata/xcschemes/fixturesTests.xcscheme
+++ b/spec/fixtures/fixtures.xcodeproj/xcshareddata/xcschemes/fixturesTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8C9A203F195965F10013B6B3"
+               BuildableName = "fixturesTests.xctest"
+               BlueprintName = "fixturesTests"
+               ReferencedContainer = "container:fixtures.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/fixtures/fixtures.xcworkspace/contents.xcworkspacedata
+++ b/spec/fixtures/fixtures.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:fixtures.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/spec/slather/cocoapods_plugin_spec.rb
+++ b/spec/slather/cocoapods_plugin_spec.rb
@@ -1,6 +1,6 @@
 require 'cocoapods'
-require File.join(File.dirname(__FILE__), '../../lib/cocoapods_plugin')
 require File.join(File.dirname(__FILE__), '..', 'spec_helper')
+require File.join(File.dirname(__FILE__), '../../lib/cocoapods_plugin')
 
 describe Slather do
   describe 'CocoaPods Plugin' do

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -149,6 +149,13 @@ describe Slather::Project do
       expect(binary_file_location).to end_with("Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests")
     end
 
+    it "should find the product path for a scheme with no buildable products" do
+      allow(fixtures_project).to receive(:scheme).and_return("fixturesTests")
+      fixtures_project.send(:configure_binary_file)
+      binary_file_location = fixtures_project.send(:binary_file)
+      expect(binary_file_location).to end_with("Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests")
+    end
+
     let(:fixture_yaml) do
         yaml_text = <<-EOF
           binary_file: "/FixtureScheme/From/Yaml/Contents/MacOS/FixturesFromYaml"

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -135,6 +135,15 @@ describe Slather::Project do
     end
 
     it "should find the product path provided a scheme" do
+      allow(fixtures_project).to receive(:scheme).and_return("fixtures")
+      fixtures_project.send(:configure_binary_file)
+      binary_file_location = fixtures_project.send(:binary_file)
+      expect(binary_file_location).to end_with("Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests")
+    end
+
+    it "should find the product path provided a workspace and scheme" do
+      allow(fixtures_project).to receive(:workspace).and_return("fixtures.xcworkspace")
+      allow(fixtures_project).to receive(:scheme).and_return("fixtures")
       fixtures_project.send(:configure_binary_file)
       binary_file_location = fixtures_project.send(:binary_file)
       expect(binary_file_location).to end_with("Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests")
@@ -202,6 +211,7 @@ describe Slather::Project do
       expect(unstubbed_project).to receive(:configure_coverage_service)
       expect(unstubbed_project).to receive(:configure_input_format)
       expect(unstubbed_project).to receive(:configure_scheme)
+      expect(unstubbed_project).to receive(:configure_workspace)
       unstubbed_project.configure
     end
   end
@@ -281,6 +291,21 @@ describe Slather::Project do
       fixtures_project.output_directory = "/already/set"
       fixtures_project.configure_output_directory
       expect(fixtures_project.output_directory).to eq("/already/set")
+    end
+  end
+
+  describe "#configure_workspace" do
+    it "should set the workspace if it has been provided in the yml and has not already been set" do
+      allow(Slather::Project).to receive(:yml).and_return({"workspace" => "fixtures.xcworkspace"})
+      fixtures_project.configure_workspace
+      expect(fixtures_project.workspace).to eq("fixtures.xcworkspace")
+    end
+
+    it "should not set the workspace if it has already been set" do
+      allow(Slather::Project).to receive(:yml).and_return({"workspace" => "fixtures.xcworkspace"})
+      fixtures_project.workspace = "MyWorkspace.xcworkspace"
+      fixtures_project.configure_workspace
+      expect(fixtures_project.workspace).to eq("MyWorkspace.xcworkspace")
     end
   end
 

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -137,7 +137,7 @@ describe Slather::Project do
     it "should find the product path provided a scheme" do
       fixtures_project.send(:configure_binary_file)
       binary_file_location = fixtures_project.send(:binary_file)
-      expect(binary_file_location).to end_with("Debug/libfixtures.a")
+      expect(binary_file_location).to end_with("Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests")
     end
 
     let(:fixture_yaml) do

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -394,7 +394,10 @@ describe Slather::Project do
         xcscheme = Xcodeproj::XCScheme.new(xcscheme_path)
         expect(xcscheme.test_action.xml_element.attributes['codeCoverageEnabled']).to eq("YES")
       end
+    end
 
+    it "should fail for unknown coverage type" do
+      expect { fixtures_project_setup.slather_setup_for_coverage "this should fail" }.to raise_error(StandardError)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,9 +16,11 @@ FIXTURES_XML_PATH = File.join(File.dirname(__FILE__), 'fixtures/cobertura.xml')
 FIXTURES_JSON_PATH = File.join(File.dirname(__FILE__), 'fixtures/gutter.json')
 FIXTURES_HTML_FOLDER_PATH = File.join(File.dirname(__FILE__), 'fixtures/fixtures_html')
 FIXTURES_PROJECT_PATH = File.join(File.dirname(__FILE__), 'fixtures/fixtures.xcodeproj')
+FIXTURES_WORKSPACE_PATH = File.join(File.dirname(__FILE__), 'fixtures/fixtures.xcworkspace')
 FIXTURES_SWIFT_FILE_PATH = File.join(File.dirname(__FILE__), 'fixtures/fixtures/Fixtures.swift')
 TEMP_DERIVED_DATA_PATH = File.join(File.dirname(__FILE__), 'DerivedData')
 TEMP_PROJECT_BUILD_PATH = File.join(TEMP_DERIVED_DATA_PATH, "libfixtures")
+TEMP_WORKSPACE_BUILD_PATH = File.join(TEMP_DERIVED_DATA_PATH, "libfixtures")
 TEMP_OBJC_GCNO_PATH = File.join(File.dirname(__FILE__), 'fixtures/ObjectiveC.gcno')
 TEMP_OBJC_GCDA_PATH = File.join(File.dirname(__FILE__), 'fixtures/ObjectiveC.gcda')
 
@@ -46,6 +48,7 @@ RSpec.configure do |config|
     FixtureHelpers.delete_derived_data
     FixtureHelpers.delete_temp_gcov_files
     `xcodebuild -project "#{FIXTURES_PROJECT_PATH}" -scheme fixtures -configuration Debug -derivedDataPath #{TEMP_PROJECT_BUILD_PATH} -enableCodeCoverage YES clean test`
+    `xcodebuild -workspace "#{FIXTURES_WORKSPACE_PATH}" -scheme fixtures -configuration Debug -derivedDataPath #{TEMP_WORKSPACE_BUILD_PATH} -enableCodeCoverage YES clean test`
   end
 
   config.after(:suite) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,10 @@
-require 'coveralls'
-Coveralls.wear!
+if ENV['SIMPLECOV']
+  require 'simplecov'
+  SimpleCov.start
+else
+  require 'coveralls'
+  Coveralls.wear!
+end
 
 require 'slather'
 require 'pry'


### PR DESCRIPTION
* Support for building with Xcode workspaces. Specify `--workspace` or add `workspace` to `.slather.yml` if you run tests in a workspace. This will fix #175 (and is probably the cause of #171, #162, and #154).

* slather errors are printed separately from the exception backtrace, which makes them look a bit less scary. More troubleshooting suggestions are included when there's an error. Fixes #8.

* Added an error if someone specifies a scheme that can't be found (or if it isn't a shared scheme).

* Updated the readme to mention workspaces and to encourage specifying a scheme to get the more accurate coverage detection.

* Fixed code coverage covering the files in `spec` and ignoring the ones `lib` (this means the coverage percentage is going to decrease).

This can be split into multiple pull requests if necessary.