### PR TITLE
Support thousands and millions of hit lines with llvm-cov.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   [Boris Bügling](https://github.com/neonichu)
   [#180](https://github.com/SlatherOrg/slather/pull/180)
 
+* Show lines that are hit thousands or millions of time in llvm-cov
+  [Kent Sutherland](https://github.com/ksuther)
+  [#179](https://github.com/SlatherOrg/slather/pull/179)
+
 ## v2.0.2
 
 * Escape the link to file names properly  

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -76,17 +76,27 @@ module Slather
       line =~ /^(\s*)(\d*)\|/
 
       if $2 == nil
-        return nil
-      end
+        # Check for thousands or millions (llvm-cov outputs hit counts as 25.3k or 3.8M)
+        did_match = line =~ /^(\s*)(\d+\.\d+)(k|M)\|/
 
-      match = $2.strip
-      case match
-      when /[0-9]+/
-        match.to_i
-      when /#+/
-        0
-      when "-"
-        nil
+        if did_match
+          count = $2.strip
+          units = $3 == 'k' ? 1000 : 1000000
+
+          count.to_f * units
+        else
+          return nil
+        end
+      else
+        match = $2.strip
+        case match
+        when /[0-9]+/
+          match.to_i
+        when /#+/
+          0
+        when "-"
+          nil
+        end
       end
     end
 

--- a/spec/slather/profdata_coverage_spec.rb
+++ b/spec/slather/profdata_coverage_spec.rb
@@ -79,6 +79,18 @@ describe Slather::ProfdataCoverageFile do
     it "should return the number of hits for the line" do
       expect(profdata_coverage_file.coverage_for_line("      10|   40|    func applicationWillTerminate(application: UIApplication) {")).to eq(10)
     end
+
+    it "should return the number of hits for a line in thousands" do
+      expect(profdata_coverage_file.coverage_for_line("  11.8k|   49|    return result;")).to eq(11800)
+    end
+
+    it "should return the number of hits for a line in millions" do
+      expect(profdata_coverage_file.coverage_for_line("  2.58M|   49|    return result;")).to eq(2580000)
+    end
+
+    it "should return the number of hits for an uncovered line" do
+      expect(profdata_coverage_file.coverage_for_line("      0|   49|    return result;")).to eq(0)
+    end
   end
 
   describe "#num_lines_tested" do


### PR DESCRIPTION
llvm-cov prints thousands as 25.3k and millions as 3.8M which requires an additional regular expression to handle them. They were being shown as no coverage before.
Fixes #161.