### PR TITLE
Improve getting scheme from xcuserdata if not found at xcshareddata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## master
 
-* Support for Xcode workspaces. Define `workspace` configuration in `.slather.yml` or use the `--workspace` argument if you build in a workspace.  
+
+## v2.1.0
+
+* Support for Xcode workspaces. Define `workspace` configuration in `.slather.yml` or use the `--workspace` argument if you build in a workspace.
 * Improved slather error messages  
   [Kent Sutherland](https://github.com/ksuther)
   [#178](https://github.com/SlatherOrg/slather/issues/178)
@@ -11,7 +14,7 @@
   [Boris Bügling](https://github.com/neonichu)
   [#180](https://github.com/SlatherOrg/slather/pull/180)
 
-* Show lines that are hit thousands or millions of time in llvm-cov
+* Show lines that are hit thousands or millions of time in llvm-cov  
   [Kent Sutherland](https://github.com/ksuther)
   [#179](https://github.com/SlatherOrg/slather/pull/179)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-* Improve getting schemes. Looks for user scheme in case no shared scheme is found.
+* Improve getting schemes. Looks for user scheme in case no shared scheme is found.  
   [Matyas Hlavacek](https://github.com/matyashlavacek)
 
 ## v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* Improve getting schemes. Looks for user scheme in case no shared scheme is found.
+  [Matyas Hlavacek](https://github.com/matyashlavacek)
 
 ## v2.1.0
 

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -330,7 +330,6 @@ module Slather
 
         # Try to look inside 'xcuserdata' if the scheme is not found in 'xcshareddata'
         if !File.file?(xcscheme_path)
-          puts "No shared scheme named '#{self.scheme}' found in #{schemes_path}. Trying to look into xcuserdata."
           schemes_path = Xcodeproj::XCScheme.user_data_dir(self.path)
           xcscheme_path = "#{schemes_path + self.scheme}.xcscheme"
         end

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -328,7 +328,14 @@ module Slather
         schemes_path = Xcodeproj::XCScheme.shared_data_dir(self.path)
         xcscheme_path = "#{schemes_path + self.scheme}.xcscheme"
 
-        raise StandardError, "No shared scheme named '#{self.scheme}' found in #{self.path}" unless File.exists? xcscheme_path
+        # Try to look inside 'xcuserdata' if the scheme is not found in 'xcshareddata'
+        if !File.file?(xcscheme_path)
+          puts "No shared scheme named '#{self.scheme}' found in #{schemes_path}. Trying to look into xcuserdata."
+          schemes_path = Xcodeproj::XCScheme.user_data_dir(self.path)
+          xcscheme_path = "#{schemes_path + self.scheme}.xcscheme"
+        end
+
+        raise StandardError, "No scheme named '#{self.scheme}' found in #{self.path}" unless File.exists? xcscheme_path
 
         xcscheme = Xcodeproj::XCScheme.new(xcscheme_path)
 

--- a/lib/slather/version.rb
+++ b/lib/slather/version.rb
@@ -1,3 +1,3 @@
 module Slather
-  VERSION = "2.0.2"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
Prior to v2.0.2 and Xcode 7.3 slather was working fine with our project, after the changes in Xcode and the fixes in slather our project started to fail on "No such file or directory" as slather was looking only into the xcshareddata directory for the scheme in xcodeproj and we don't have the scheme shared yet. 
I have modified the code to also look into the xcuserdata directory in case it cannot find the scheme in xcshareddata, which seems logical to me. 
Was there any specific reason to look just into the shared dir for the scheme?