### PR TITLE
Fix scheme/workspace configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   [Kent Sutherland](https://github.com/ksuther)
   [#179](https://github.com/SlatherOrg/slather/pull/179)
 
+* Fix for setting scheme/workspace from configuration file.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#183](https://github.com/SlatherOrg/slather/pull/183)
+
 ## v2.0.2
 
 * Escape the link to file names properly  

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -208,6 +208,8 @@ module Slather
 
     def configure
       begin
+        configure_scheme
+        configure_workspace
         configure_build_directory
         configure_ignore_list
         configure_ci_service
@@ -216,8 +218,6 @@ module Slather
         configure_source_directory
         configure_output_directory
         configure_input_format
-        configure_scheme
-        configure_workspace
         configure_binary_file
       rescue => e
         puts e.message


### PR DESCRIPTION
Since those values are potentially needed for `configure_build_directory`, they need to be configured before it is.