### PR TITLE
Output thousands and millions of hits as integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   [Matyas Hlavacek](https://github.com/matyashlavacek)
   [#182](https://github.com/SlatherOrg/slather/issues/182)
 
+* Fix for hit counts in thousands or millions being output as floats intead of integers
+  [Carl Hill-Popper](https://github.com/chillpop)
+  [#190](https://github.com/SlatherOrg/slather/pull/190)
+
 ## v2.1.0
 
 * Support for Xcode workspaces. Define `workspace` configuration in `.slather.yml` or use the `--workspace` argument if you build in a workspace.

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -83,7 +83,7 @@ module Slather
           count = $2.strip
           units = $3 == 'k' ? 1000 : 1000000
 
-          count.to_f * units
+          (count.to_f * units).to_i
         else
           return nil
         end

--- a/spec/slather/profdata_coverage_spec.rb
+++ b/spec/slather/profdata_coverage_spec.rb
@@ -80,12 +80,16 @@ describe Slather::ProfdataCoverageFile do
       expect(profdata_coverage_file.coverage_for_line("      10|   40|    func applicationWillTerminate(application: UIApplication) {")).to eq(10)
     end
 
-    it "should return the number of hits for a line in thousands" do
-      expect(profdata_coverage_file.coverage_for_line("  11.8k|   49|    return result;")).to eq(11800)
+    it "should return the number of hits for a line in thousands as an integer" do
+      result = profdata_coverage_file.coverage_for_line("  11.8k|   49|    return result;")
+      expect(result).to eq(11800)
+      expect(result).to be_a(Fixnum)
     end
 
-    it "should return the number of hits for a line in millions" do
-      expect(profdata_coverage_file.coverage_for_line("  2.58M|   49|    return result;")).to eq(2580000)
+    it "should return the number of hits for a line in millions as an integer" do
+      result = profdata_coverage_file.coverage_for_line("  2.58M|   49|    return result;")
+      expect(result).to eq(2580000)
+      expect(result).to be_a(Fixnum)
     end
 
     it "should return the number of hits for an uncovered line" do


### PR DESCRIPTION
Previously (in #179), hit counts in the thousands or millions were output as floats and lower hit counts were output as integers.  This change makes all hit counts consistent.