### PR TITLE
Search xcworkspaces for schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   [Matyas Hlavacek](https://github.com/matyashlavacek)
   [#182](https://github.com/SlatherOrg/slather/issues/182)
 
+* Search Xcode workspaces for schemes. Workspaces are checked if no matching scheme is found in the project.
+  [Kent Sutherland](https://github.com/ksuther)
+  [#193](https://github.com/SlatherOrg/slather/pull/193), [#191](https://github.com/SlatherOrg/slather/issues/191)
+
 * Fix for hit counts in thousands or millions being output as floats intead of integers
   [Carl Hill-Popper](https://github.com/chillpop)
   [#190](https://github.com/SlatherOrg/slather/pull/190)

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -334,6 +334,17 @@ module Slather
           xcscheme_path = "#{schemes_path + self.scheme}.xcscheme"
         end
 
+        if self.workspace and !File.file?(xcscheme_path)
+          # No scheme was found in the xcodeproj, check the workspace
+          schemes_path = Xcodeproj::XCScheme.shared_data_dir(self.workspace)
+          xcscheme_path = "#{schemes_path + self.scheme}.xcscheme"
+
+          if !File.file?(xcscheme_path)
+            schemes_path = Xcodeproj::XCScheme.user_data_dir(self.workspace)
+            xcscheme_path = "#{schemes_path + self.scheme}.xcscheme"
+          end
+        end
+
         raise StandardError, "No scheme named '#{self.scheme}' found in #{self.path}" unless File.exists? xcscheme_path
 
         xcscheme = Xcodeproj::XCScheme.new(xcscheme_path)

--- a/spec/fixtures/fixtures.xcworkspace/xcshareddata/xcschemes/fixturesTestsWorkspace.xcscheme
+++ b/spec/fixtures/fixtures.xcworkspace/xcshareddata/xcschemes/fixturesTestsWorkspace.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8C9A203F195965F10013B6B3"
+               BuildableName = "fixturesTests.xctest"
+               BlueprintName = "fixturesTests"
+               ReferencedContainer = "container:fixtures.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,7 @@ RSpec.configure do |config|
     FixtureHelpers.delete_derived_data
     FixtureHelpers.delete_temp_gcov_files
     `xcodebuild -project "#{FIXTURES_PROJECT_PATH}" -scheme fixtures -configuration Debug -derivedDataPath #{TEMP_PROJECT_BUILD_PATH} -enableCodeCoverage YES clean test`
-    `xcodebuild -workspace "#{FIXTURES_WORKSPACE_PATH}" -scheme fixtures -configuration Debug -derivedDataPath #{TEMP_WORKSPACE_BUILD_PATH} -enableCodeCoverage YES clean test`
+    `xcodebuild -workspace "#{FIXTURES_WORKSPACE_PATH}" -scheme fixturesTestsWorkspace -configuration Debug -derivedDataPath #{TEMP_WORKSPACE_BUILD_PATH} -enableCodeCoverage YES clean test`
   end
 
   config.after(:suite) do


### PR DESCRIPTION
Add support for searching Xcode workspaces for schemes. Workspaces are checked if no matching scheme is found in the project.
Fixes #191.