### PR TITLE
Fix for binary-file argument sometimes getting ignored

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -322,7 +322,7 @@ module Slather
     end
 
     def configure_binary_file
-      if self.input_format == "profdata"
+      if self.binary_file == nil and self.input_format == "profdata"
         binary_file_yml = self.class.yml["binary_file"]
 
         # Need to check the type in the config file because binary_file can be a string or array

--- a/spec/fixtures/fixtures.xcworkspace/xcshareddata/xcschemes/fixturesTestsWorkspace.xcscheme
+++ b/spec/fixtures/fixtures.xcworkspace/xcshareddata/xcschemes/fixturesTestsWorkspace.xcscheme
@@ -5,6 +5,22 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8C9A202C195965F10013B6B3"
+               BuildableName = "libfixtures.a"
+               BlueprintName = "fixtures"
+               ReferencedContainer = "container:fixtures.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -23,6 +39,15 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8C9A202C195965F10013B6B3"
+            BuildableName = "libfixtures.a"
+            BlueprintName = "fixtures"
+            ReferencedContainer = "container:fixtures.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -36,6 +61,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8C9A202C195965F10013B6B3"
+            BuildableName = "libfixtures.a"
+            BlueprintName = "fixtures"
+            ReferencedContainer = "container:fixtures.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -45,6 +79,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8C9A202C195965F10013B6B3"
+            BuildableName = "libfixtures.a"
+            BlueprintName = "fixtures"
+            ReferencedContainer = "container:fixtures.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -136,6 +136,14 @@ describe Slather::Project do
       allow(Dir).to receive(:[]).with("#{build_directory}/Build/Intermediates/CodeCoverage/FixtureScheme/**/*.xctest").and_return(["#{build_directory}/Build/Intermediates/CodeCoverage/FixtureScheme/FixtureAppTests.xctest"])
     end
 
+    it "should use binary_file" do
+      fixtures_project.binary_file = ["/path/to/binary"]
+      fixtures_project.send(:configure_binary_file)
+      binary_file_location = fixtures_project.send(:binary_file)
+      expect(binary_file_location.count).to eq(1)
+      expect(binary_file_location.first).to eq("/path/to/binary")
+    end
+
     it "should find the product path provided a scheme" do
       allow(fixtures_project).to receive(:scheme).and_return("fixtures")
       fixtures_project.send(:configure_binary_file)


### PR DESCRIPTION
configure_binary_file was ignoring binary_file and calling find_binary_file even if binary_file was defined manually.
Also fixed the xcodebuild command for fixtureTestsWorkspace showing an error when running the tests.