### PR TITLE
Support for specifying llvm-cov source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
   [Kent Sutherland](https://github.com/ksuther)
   [#188](https://github.com/SlatherOrg/slather/pull/188)
 
+
+* Support for specifying source file patterns using the `--source-files` option or the source_files key in `.slather.yml`
+  [Matej Bukovinski](https://github.com/matej)
+  [#201](https://github.com/SlatherOrg/slather/pull/201)
+
 * Improve getting schemes. Looks for user scheme in case no shared scheme is found.  
   [Matyas Hlavacek](https://github.com/matyashlavacek)
   [#182](https://github.com/SlatherOrg/slather/issues/182)

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -26,7 +26,7 @@ class CoverageCommand < Clamp::Command
   option ["--workspace"], "WORKSPACE", "The workspace that the project was built in"
   option ["--binary-file"], "BINARY_FILE", "The binary file against the which the coverage will be run", :multivalued => true
   option ["--binary-basename"], "BINARY_BASENAME", "Basename of the file against which the coverage will be run", :multivalued => true
-  option ["--source-files"], "SOURCE_FILES", "A Dir.glob compatible pattern used to limit the lookup to specific source files", :multivalued => true
+  option ["--source-files"], "SOURCE_FILES", "A Dir.glob compatible pattern used to limit the lookup to specific source files. Ignored in gcov mode.", :multivalued => true
 
   def execute
     puts "Slathering..."

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -26,6 +26,7 @@ class CoverageCommand < Clamp::Command
   option ["--workspace"], "WORKSPACE", "The workspace that the project was built in"
   option ["--binary-file"], "BINARY_FILE", "The binary file against the which the coverage will be run", :multivalued => true
   option ["--binary-basename"], "BINARY_BASENAME", "Basename of the file against which the coverage will be run", :multivalued => true
+  option ["--source-files"], "SOURCE_FILES", "A Dir.glob compatible pattern used to limit the lookup to specific source files", :multivalued => true
 
   def execute
     puts "Slathering..."
@@ -42,6 +43,7 @@ class CoverageCommand < Clamp::Command
     setup_workspace
     setup_binary_file
     setup_binary_basename
+    setup_source_files
 
     project.configure
 
@@ -132,5 +134,9 @@ class CoverageCommand < Clamp::Command
 
   def setup_binary_basename
     project.binary_basename = binary_basename_list if !binary_basename_list.empty?
+  end
+
+  def setup_source_files
+    project.source_files = source_files_list if !source_files_list.empty?
   end
 end

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -25,7 +25,7 @@ module Slather
 
     def path_on_first_line?
       path = self.source.split("\n")[0].sub ":", ""
-      Pathname(path).exist?
+      !path.include?("1|//")
     end
 
     def source_file_pathname

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -80,7 +80,6 @@ module Slather
 
     def line_coverage_data
       source_code_lines.map do |line|
-        puts "L: #{line}"
         coverage_for_line(line)
       end
     end

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -16,12 +16,17 @@ module Slather
     end
 
     def create_line_data
-      all_lines = self.source.split("\n")[1..-1]
+      all_lines = source_code_lines
       line_data = Hash.new
       all_lines.each { |line| line_data[line_number_in_line(line)] = line }
       self.line_data = line_data
     end
     private :create_line_data
+
+    def path_on_first_line?
+      path = self.source.split("\n")[0].sub ":", ""
+      Pathname(path).exist?
+    end
 
     def source_file_pathname
       @source_file_pathname ||= begin
@@ -30,8 +35,16 @@ module Slather
       end
     end
 
+    def source_file_pathname= (source_file_pathname)
+        @source_file_pathname = source_file_pathname
+    end
+
     def source_file
       File.new(source_file_pathname)
+    end
+
+    def source_code_lines
+      self.source.split("\n")[(path_on_first_line? ? 1 : 0)..-1]
     end
 
     def source_data
@@ -40,7 +53,7 @@ module Slather
 
     def all_lines
       if @all_lines == nil
-        @all_lines = self.source.split("\n")[1..-1]
+        @all_lines = source_code_lines
       end
       @all_lines
     end
@@ -66,7 +79,8 @@ module Slather
     end
 
     def line_coverage_data
-      self.source.split("\n")[1..-1].map do |line|
+      source_code_lines.map do |line|
+        puts "L: #{line}"
         coverage_for_line(line)
       end
     end

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -134,6 +134,7 @@ module Slather
       ["MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertionsImpl.h",
         "MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/objc/objc.h",
         "MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertions.h",
+        # This indicates a llvm-cov coverage warning (happens with ccache in some cases)
         "isn't covered."]
     end
     private :platform_ignore_list

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -133,7 +133,8 @@ module Slather
     def platform_ignore_list
       ["MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertionsImpl.h",
         "MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/objc/objc.h",
-        "MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertions.h"]
+        "MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertions.h",
+        "isn't covered."]
     end
     private :platform_ignore_list
   end

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -148,7 +148,8 @@ module Slather
       ["MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertionsImpl.h",
         "MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/objc/objc.h",
         "MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertions.h",
-        # This indicates a llvm-cov coverage warning (happens with ccache in some cases)
+        # This indicates a llvm-cov coverage warning (occurs if a passed in source file 
+        # is not covered or with ccache in some cases).
         "isn't covered."]
     end
     private :platform_ignore_list

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -130,6 +130,8 @@ module Slather
 
           coverage_files.concat(files.map do |source|
             coverage_file = coverage_file_class.new(self, source)
+            # If a single source file is used, the resulting output does not contain the file name.
+            coverage_file.source_file_pathname = source_files.first if source_files.count == 1
             !coverage_file.ignored? ? coverage_file : nil
           end.compact)
 

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -329,7 +329,7 @@ module Slather
 
     def configure_binary_file
       if self.input_format == "profdata"
-        self.binary_file = load_option_array("binary_file")
+        self.binary_file = load_option_array("binary_file") || find_binary_files
       end
     end
 

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -322,7 +322,7 @@ module Slather
     end
 
     def configure_binary_file
-      if self.input_format == "profdata"
+      if self.input_format == "profdata"  && !self.binary_file
         binary_file_yml = self.class.yml["binary_file"]
 
         # Need to check the type in the config file because binary_file can be a string or array

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -466,11 +466,23 @@ module Slather
     end
 
     def find_source_files
-      patterns = self.source_files ? self.source_files : self.class.yml["source_files"]
-      return if patterns.nil?
+      if self.source_files
+        source_files = self.source_files
+      else
+        source_files_yml = self.class.yml["source_files"]
+
+        # Need to check the type in the config file because source_files can be a string or array
+        if source_files_yml and source_files_yml.is_a? Array
+          source_files = source_files_yml
+        elsif source_files_yml
+          source_files = [source_files_yml]
+        else
+          return
+        end
+      end
 
       current_dir = Pathname("./").realpath
-      paths = patterns.flat_map { |pattern| Dir.glob(pattern) }.uniq
+      paths = source_files.flat_map { |pattern| Dir.glob(pattern) }.uniq
 
       paths.map do |path|
         source_file_absolute_path = Pathname(path).realpath

--- a/spec/slather/profdata_coverage_spec.rb
+++ b/spec/slather/profdata_coverage_spec.rb
@@ -139,6 +139,12 @@ describe Slather::ProfdataCoverageFile do
       expect(ignorable_file.ignored?).to be_truthy
     end
 
+    it "should ignore warnings" do
+      ignorable_file = Slather::ProfdataCoverageFile.new(fixtures_project, "warning The file '/Users/ci/.ccache/tmp/CALayer-KI.stdout.macmini08.92540.QAQaxt.mi' isn't covered.")
+
+      expect(ignorable_file.ignored?).to be_truthy
+    end
+
   end
 
 end

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -464,4 +464,35 @@ describe Slather::Project do
       fixtures_project.send(:configure)
     end
   end
+
+  describe "#source_files" do
+
+    let(:fixtures_project) do
+      proj = Slather::Project.open(FIXTURES_PROJECT_PATH)
+      proj.build_directory = TEMP_DERIVED_DATA_PATH
+      proj.input_format = "profdata"
+      proj.source_files = ["./**/fixtures{,Two}.m"]
+      proj.binary_basename = ["fixturesTests", "libfixturesTwo"]
+      proj.configure
+      proj
+    end
+
+    it "should find relevant source files" do
+      source_files = fixtures_project.find_source_files
+      expect(source_files.count).to eq(2)
+      expect(source_files.first.to_s).to include("fixtures.m")
+      expect(source_files.last.to_s).to include("fixturesTwo.m")
+    end
+
+    it "should print out the coverage for each file, and then total coverage" do
+      ["spec/fixtures/fixtures/fixtures.m: 3 of 6 lines (50.00%)",
+      "spec/fixtures/fixturesTwo/fixturesTwo.m: 6 of 6 lines (100.00%)",
+      "Test Coverage: 75.00%"
+      ].each do |line|
+        expect(fixtures_project).to receive(:puts).with(line)
+      end
+      fixtures_project.post
+    end
+  end
+
 end


### PR DESCRIPTION
This PR addresses some issues we had to overcome to make Slather work (well) with our test setup at PSPDFKit. 

See the commit message for details but the essential part is:

>Added a way to specify source file filters.
>- Uses ruby’s Dir.glob for maximum flexibility and easy lookup.
>- Files are passed to llvm-cov to speed up processing. 
>- If ignore patterns are also given, they are applied before the files are passed to llvm-cov so ignored files are not processed at all. 
>- If multiple binaries are processed, the already processed files get excluded during subsequent runs, speeding up processing, if there is a lot of overlap between the binaries.

For our relatively complex test setup where we have multiple test projects covering multiple libraries with quite a bit of overlap between coverage, this resulted in the processing time going down from about 2 minutes to around 30 seconds. 

The new option does not apply to gcov files. I haven't looked closely, but from glancing ove the implementation it seems like it would not make any sense there. 