### PR TITLE
Fix for Corrupted cobertura file format #196

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Fix for correct line number for lines that are hit thousands or millions of time in llvm-cov.  
+  [Mihai Parv](https://github.com/mihaiparv)
+  [#202](https://github.com/SlatherOrg/slather/pull/202), [#196](https://github.com/SlatherOrg/slather/issues/196)
+
 * Generate coverate for multiple binaries by passing multiple `--binary-basename` or `--binary-file` arguments, or by using an array in `.slather.yml`  
   [Kent Sutherland](https://github.com/ksuther)
   [#188](https://github.com/SlatherOrg/slather/pull/188)

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -61,6 +61,17 @@ module Slather
           when /[0-9]+/
             return match.to_i
         end
+      else
+        # llvm-cov outputs hit counts as 25.3k or 3.8M, so check this pattern as well
+        did_match = line =~ /^(\s*)(\d+\.\d+)(k|M)\|(\s*)(\d+)\|/
+
+        if did_match
+          match = $5.strip
+          case match
+            when /[0-9]+/
+              return match.to_i
+          end
+        end
       end
       0
     end

--- a/spec/slather/profdata_coverage_spec.rb
+++ b/spec/slather/profdata_coverage_spec.rb
@@ -70,8 +70,16 @@ describe Slather::ProfdataCoverageFile do
   end
 
   describe "#line_number_in_line" do
-    it "should return the correct line number" do
+    it "should return the correct line number for coverage represented as decimals" do
       expect(profdata_coverage_file.line_number_in_line("      0|   40|    func applicationWillTerminate(application: UIApplication) {")).to eq(40)
+    end
+
+    it "should return the correct line number for coverage represented as thousands" do
+      expect(profdata_coverage_file.line_number_in_line("  11.8k|   41|    func applicationWillTerminate(application: UIApplication) {")).to eq(41)
+    end
+
+    it "should return the correct line number for coverage represented as milions" do
+      expect(profdata_coverage_file.line_number_in_line("  2.58M|   42|    func applicationWillTerminate(application: UIApplication) {")).to eq(42)
     end
   end
 


### PR DESCRIPTION
Added pattern to match line numbers when llvm-cov output includes thousands as 25.3k and millions as 3.8M