### PR TITLE
Add --decimals flag for HTML and simple output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## master
 
-* Add `slather version` command
+* Add `--decimals` flag  
+  [bootstraponline](https://github.com/bootstraponline)
+  [#207](https://github.com/SlatherOrg/slather/pull/207)
+
+* Add `slather version` command  
   [bootstraponline](https://github.com/bootstraponline)
   [#208](https://github.com/SlatherOrg/slather/pull/208)
 

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -27,6 +27,7 @@ class CoverageCommand < Clamp::Command
   option ["--binary-file"], "BINARY_FILE", "The binary file against the which the coverage will be run", :multivalued => true
   option ["--binary-basename"], "BINARY_BASENAME", "Basename of the file against which the coverage will be run", :multivalued => true
   option ["--source-files"], "SOURCE_FILES", "A Dir.glob compatible pattern used to limit the lookup to specific source files. Ignored in gcov mode.", :multivalued => true
+  option ["--decimals"], "DECIMALS", "The amount of decimals to use for % coverage reporting"
 
   def execute
     puts "Slathering..."
@@ -44,6 +45,7 @@ class CoverageCommand < Clamp::Command
     setup_binary_file
     setup_binary_basename
     setup_source_files
+    setup_decimals
 
     project.configure
 
@@ -138,5 +140,9 @@ class CoverageCommand < Clamp::Command
 
   def setup_source_files
     project.source_files = source_files_list if !source_files_list.empty?
+  end
+
+  def setup_decimals
+    project.decimals = decimals if decimals
   end
 end

--- a/lib/slather/coverage_service/html_output.rb
+++ b/lib/slather/coverage_service/html_output.rb
@@ -79,7 +79,7 @@ module Slather
           cov.h4 {
             percentage = (total_tested_lines / total_relevant_lines.to_f) * 100.0
             cov.span "Total Coverage : "
-            cov.span '%.2f%%' % percentage, :class => class_for_coverage_percentage(percentage), :id => "total_coverage"
+            cov.span decimal_f(percentage) + '%', :class => class_for_coverage_percentage(percentage), :id => "total_coverage"
           }
 
           cov.input(:class => "search", :placeholder => "Search")
@@ -105,7 +105,7 @@ module Slather
                 cov.tr {
                   percentage = coverage_file.percentage_lines_tested
 
-                  cov.td { cov.span '%.2f' % percentage, :class => "percentage #{class_for_coverage_percentage(percentage)} data_percentage" }
+                  cov.td { cov.span decimal_f(percentage), :class => "percentage #{class_for_coverage_percentage(percentage)} data_percentage" }
                   cov.td(:class => "data_filename") {
                     cov.a filename, :href => filename_link
                   }
@@ -140,7 +140,7 @@ module Slather
         builder = Nokogiri::HTML::Builder.with(template.at('#reports')) { |cov|
           cov.h2(:class => "cov_title") {
             cov.span("Coverage for \"#{filename}\"" + (!is_file_empty ? " : " : ""))
-            cov.span("#{'%.2f' % percentage}%", :class => class_for_coverage_percentage(percentage)) unless is_file_empty
+            cov.span("#{decimal_f(percentage)}%", :class => class_for_coverage_percentage(percentage)) unless is_file_empty
           }
 
           cov.h4("(#{coverage_file.num_lines_tested} of #{coverage_file.num_lines_testable} relevant lines covered)", :class => "cov_subtitle")

--- a/lib/slather/coverage_service/simple_output.rb
+++ b/lib/slather/coverage_service/simple_output.rb
@@ -19,7 +19,7 @@ module Slather
 
           lines_tested = coverage_file.num_lines_tested
           total_lines = coverage_file.num_lines_testable
-          percentage = '%.2f' % [coverage_file.percentage_lines_tested]
+          percentage = decimal_f([coverage_file.percentage_lines_tested])
 
           total_project_lines_tested += lines_tested
           total_project_lines += total_lines
@@ -42,7 +42,7 @@ module Slather
           puts "##teamcity[buildStatisticValue key='CodeCoverageAbsLTotal' value='%i']" % total_project_lines
         end
 
-        total_percentage = '%.2f' % [(total_project_lines_tested / total_project_lines.to_f) * 100.0]
+        total_percentage = decimal_f([(total_project_lines_tested / total_project_lines.to_f) * 100.0])
         puts "Test Coverage: #{total_percentage}%"
       end
 

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -503,4 +503,20 @@ describe Slather::Project do
     end
   end
 
+  def decimal_f *args
+    fixtures_project.decimal_f *args
+  end
+
+  describe '#decimal_f' do
+    it 'should preserve length 2 decimals for backwards compatibility' do
+      expect(decimal_f('100.00')).to eq('100.00')
+      expect(decimal_f('50.00')).to eq('50.00')
+    end
+
+    it 'should convert length >= 3 decimals to floats' do
+      fixtures_project.decimals = 3
+      expect(decimal_f('100.000')).to eq('100.0')
+      expect(decimal_f('50.00000')).to eq('50.0')
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 if ENV['SIMPLECOV']
   require 'simplecov'
   SimpleCov.start
-else
+elsif ENV['TRAVIS']
   require 'coveralls'
   Coveralls.wear!
 end


### PR DESCRIPTION
.to_f is used to avoid excessive zeros.
0.0000.to_f => 0.0

Fix #205