### PR TITLE
Update project.rb

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -277,7 +277,7 @@ module Slather
     end
 
     def configure_input_format
-      self.input_format ||= self.class.yml["input_format"] || input_format
+      self.input_format = self.class.yml["input_format"] || self.input_format || input_format
     end
 
     def input_format=(format)


### PR DESCRIPTION
Look at issue #225 "input_format in .slather.yml is not being used".

I have older gcov coverage using 7.3.1 and it keeps switching to profdata. I have define the following in .slather.yml:

```yml
coverage_service: cobertura_xml
input_format: gcov
xcodeproj: Lib.xcodeproj
scheme: LibTests
source_directory: Lib
output_directory: ./TempTest/slather
ignore:
  - LibApp/*
  - LibTests/*
```

I think you might need to change:
`self.input_format ||= self.class.yml["input_format"] || input_format`

to

`self.input_format = self.class.yml["input_format"] || self.input_format || input_format`

This will give flexibility to generate based on correct needed input.