### PR TITLE
Slather Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 * Add buildkite support to coveralls   
   [David Hardiman](https://github.com/dhardiman)
   [#98](https://github.com/venmo/slather/pull/98)
-  
+* Update to xcodeproj 0.28.0 to avoid collisions with Cocoapods 0.39.0   
+  [Julian Krumow](https://github.com/tarbrain)   
+  [#106](https://github.com/venmo/slather/pull/106)/[#109](https://github.com/venmo/slather/pull/109)
 
 ## v1.8.1
 * Fixed dependency conflict with CocoaPods v0.38

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Generate test coverage reports for Xcode projects & hook it into CI.
 | ------- |:--------:|
 | [Parsimmon](https://github.com/ayanonagon/Parsimmon) | [![Parsimmon Coverage](https://coveralls.io/repos/ayanonagon/Parsimmon/badge.svg?branch=master)](https://coveralls.io/r/ayanonagon/Parsimmon?branch=master) |
 | [VENCore](https://github.com/venmo/VENCore) | [![VENCore Coverage](https://coveralls.io/repos/venmo/VENCore/badge.svg?branch=master)](https://coveralls.io/r/venmo/VENCore?branch=master) |
-| [CGFloatType](https://github.com/kylef/CGFloatType) | [![CGFloatType Coverage](https://coveralls.io/repos/kylef/CGFloatType/badge.svg?branch=master)](https://coveralls.io/r/kylef/CGFloatType?branch=master) |
 | [DAZABTest](https://github.com/dasmer/DAZABTest) | [![DAZABTest Coverage](https://coveralls.io/repos/dasmer/DAZABTest/badge.svg?branch=master)](https://coveralls.io/r/dasmer/DAZABTest?branch=master) |
 | [TBStateMachine](https://github.com/tarbrain/TBStateMachine) | [![TBStateMachine Coverage](https://coveralls.io/repos/tarbrain/TBStateMachine/badge.svg?branch=master)](https://coveralls.io/r/tarbrain/TBStateMachine?branch=master) |
 

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -87,7 +87,7 @@ module Slather
       end.compact
 
       if coverage_files.empty?
-        raise StandardError, "No coverage files found. Are you sure your project is setup for generating coverage files? Try `slather setup your/project.pbxproj`"
+        raise StandardError, "No coverage files found. Are you sure your project is setup for generating coverage files? Try `slather setup your/project.xcodeproj`"
       else
         dedupe(coverage_files)
       end

--- a/lib/slather/version.rb
+++ b/lib/slather/version.rb
@@ -1,3 +1,3 @@
 module Slather
-  VERSION = "1.8.1"
+  VERSION = "1.8.2"
 end

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "clamp", "~> 0.6"
   spec.add_dependency "xcodeproj"
+  spec.add_dependency "xcodeproj", "~> 0.28.0"
   spec.add_dependency "nokogiri", "~> 1.6.3"
 end

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "rspec", "~> 3.3"
   spec.add_development_dependency "pry", "~> 0.9"
-  spec.add_development_dependency "cocoapods", "~> 0.39.0.beta.4"
+  spec.add_development_dependency "cocoapods"
   spec.add_development_dependency "json_spec", "~> 1.1.4"
   spec.add_development_dependency "equivalent-xml", "~> 0.5.1"
 
   spec.add_dependency "clamp", "~> 0.6"
-  spec.add_dependency "xcodeproj", "~> 0.27.2"
+  spec.add_dependency "xcodeproj"
   spec.add_dependency "nokogiri", "~> 1.6.3"
 end

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -28,6 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "clamp", "~> 0.6"
   spec.add_dependency "xcodeproj"
-  spec.add_dependency "xcodeproj", "~> 0.28.0"
   spec.add_dependency "nokogiri", "~> 1.6.3"
 end


### PR DESCRIPTION
FYI - the latest Slather supports cobertura reports:

https://github.com/SlatherOrg/slather (the official gem)

```yml
# .slather.yml

coverage_service: cobertura_xml
xcodeproj: path/to/project.xcodeproj
scheme: YourXcodeSchemeName
source_directory: path/to/sources/to/include
output_directory: path/to/xml_report
ignore:
  - ExamplePodCode/*
  - ProjectTestsGroup/*
```