### PR TITLE
Fixes #232

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Fixes broken fallback value of input_format inside configure_input_format 
+  [sbhklr](https://github.com/sbhklr)
+  [#233](https://github.com/SlatherOrg/slather/pull/233), [#232](https://github.com/SlatherOrg/slather/issues/232)
+
 * Add `--travispro` flag  
   [sbhklr](https://github.com/sbhklr)
   [#223](https://github.com/SlatherOrg/slather/pull/223), [#219](https://github.com/SlatherOrg/slather/issues/219)

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -277,7 +277,7 @@ module Slather
     end
 
     def configure_input_format
-      self.input_format ||= self.class.yml["input_format"] || input_format
+      self.input_format ||= (self.class.yml["input_format"] || "auto")
     end
 
     def input_format=(format)

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -394,6 +394,28 @@ describe Slather::Project do
 
   end
 
+  describe "#configure_input_format" do
+    it "should set the input_format if it has been provided by the yml" do
+      allow(Slather::Project).to receive(:yml).and_return({"input_format" => "gcov"})
+      fixtures_project.configure_input_format
+      expect(fixtures_project.input_format).to eq("gcov")
+    end
+
+    it "should default the input_format to auto if nothing is provided in the yml" do
+      allow(Slather::Project).to receive(:yml).and_return({})
+      expect(fixtures_project).to receive(:input_format=).with("auto")
+      fixtures_project.configure_input_format
+    end
+
+    it "should not set the input_format if it has already been set" do
+      allow(Slather::Project).to receive(:yml).and_return({"input_format" => "some_format" })
+      fixtures_project.input_format = "gcov"
+      expect(fixtures_project).to_not receive(:input_format=)
+      fixtures_project.configure_input_format
+    end
+
+  end
+
   describe "#coverage_service=" do
     it "should extend Slather::CoverageService::Coveralls and set coverage_service = :coveralls if given coveralls" do
       expect(fixtures_project).to receive(:extend).with(Slather::CoverageService::Coveralls)


### PR DESCRIPTION
Fixes an incorrect fallback value for `input_format` and adds test cases for `configure_input_format` (See #232)