### PR TITLE
Invoke xcodebuild with CODE_SIGNING_* flags to avoid hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Fix hanging `xcodebuild` invocation when getting derived data path.  
+  [arthurtoper](https://github.com/arthurtoper)
+  [#238](https://github.com/SlatherOrg/slather/pull/238), [#197](https://github.com/SlatherOrg/slather/issues/197), [#212](https://github.com/SlatherOrg/slather/issues/212), [#234](https://github.com/SlatherOrg/slather/issues/234)
+
 ## v2.3.0
 
 * Fixes broken fallback value of `input_format` inside `configure_input_format`  

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -3,7 +3,6 @@ require 'xcodeproj'
 require 'json'
 require 'yaml'
 require 'shellwords'
-require 'open3'
 
 module Xcodeproj
 

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -80,19 +80,12 @@ module Slather
         schemeArgument = "-scheme \"#{self.scheme}\""
         buildAction = "test"
       else
-        schemeArgument = ''
-        buildAction = ''
+        schemeArgument = nil
+        buildAction = nil
       end
 
-      build_settings = ''
-      Open3.popen2e('xcodebuild', projectOrWorkspaceArgument, schemeArgument, '-showbuildsettings', buildAction) do |stdin, stdout_err, wait_thr|
-        stdin.close
-        while line = stdout_err.gets
-          build_settings += line || ''
-        end
-        build_settings += stdout_err.gets(nil) || '' # Flush
-        exit_status = wait_thr.value.exitstatus
-      end
+      # redirect stderr to avoid xcodebuild errors being printed.
+      build_settings = `xcodebuild #{projectOrWorkspaceArgument} #{schemeArgument} -showBuildSettings #{buildAction} CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO 2>&1`
 
       if build_settings
         derived_data_path = build_settings.match(/ OBJROOT = (.+)/)

--- a/lib/slather/version.rb
+++ b/lib/slather/version.rb
@@ -1,3 +1,3 @@
 module Slather
-  VERSION = '2.3.0b' unless defined?(Slather::VERSION)
+  VERSION = '2.3.0' unless defined?(Slather::VERSION)
 end

--- a/lib/slather/version.rb
+++ b/lib/slather/version.rb
@@ -1,3 +1,3 @@
 module Slather
-  VERSION = '2.3.0' unless defined?(Slather::VERSION)
+  VERSION = '2.3.0b' unless defined?(Slather::VERSION)
 end


### PR DESCRIPTION
Hi,

We are using Slather in a fairly bespoke CI environment where unfortunately it's occasionally been hanging indefinitely when shelling out to xcodebuild. This PR implementation tweak using Open3.popen2e seems to fix the issue for us; we've not seen a single hang since making the change. However, I'm by no means a Ruby stream / I/O expert so if someone could suggest a better implementation I'll very happily adopt it.

I don't believe this change introduces any problems - certainly existing specs all still pass - but I'd appreciate it if others could give it a test too. I've not added any new specs to cover this as it's a pretty non-functional change, but happy to look into that if required.

Many thanks,

Arthur

EDIT - Forgot to mention, I'm pretty sure my version does not suppress STDERR as the original does (with the 'redirect stderr to avoid xcodebuild errors being printed' comment). Hope this isn't too much of a problem.