### PR TITLE
Properly handle uncovered files when the --source-files option is used

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -130,8 +130,12 @@ module Slather
       if self.binary_file
         self.binary_file.each do |binary_path|
           files = profdata_llvm_cov_output(binary_path, source_files).split("\n\n")
+          covered_files = []
+          files.each do |file|
+            covered_files << file.each_line.reject{ |line| /warning: The file .* isn't covered/ =~ line }.join
+          end
 
-          coverage_files.concat(files.map do |source|
+          coverage_files.concat(covered_files.map do |source|
             coverage_file = coverage_file_class.new(self, source)
             # If a single source file is used, the resulting output does not contain the file name.
             coverage_file.source_file_pathname = source_files.first if source_files.count == 1


### PR DESCRIPTION
Before this patch:
```
$ slather coverage --source-files "XCDYouTubeKit/*.[hm]" --scheme "XCDYouTubeKit Framework" XCDYouTubeKit.xcodeproj
Slathering...
XCDYouTubeKit/XCDYouTubeVideo+Private.h: 1 of 1 lines (100.00%)
Test Coverage: 100.00%
Slathered
```

After this patch:
```
$ slather coverage --source-files "XCDYouTubeKit/*.[hm]" --scheme "XCDYouTubeKit Framework" XCDYouTubeKit.xcodeproj
Slathering...
XCDYouTubeKit/XCDYouTubeClient.m: 51 of 54 lines (94.44%)
XCDYouTubeKit/XCDYouTubeLogger+Private.h: 6 of 6 lines (100.00%)
XCDYouTubeKit/XCDYouTubeLogger.m: 17 of 33 lines (51.52%)
XCDYouTubeKit/XCDYouTubePlayerScript.m: 67 of 71 lines (94.37%)
XCDYouTubeKit/XCDYouTubeVideo+Private.h: 1 of 1 lines (100.00%)
XCDYouTubeKit/XCDYouTubeVideo.m: 189 of 202 lines (93.56%)
XCDYouTubeKit/XCDYouTubeVideoOperation.m: 251 of 262 lines (95.80%)
XCDYouTubeKit/XCDYouTubeVideoPlayerViewController.m: 111 of 131 lines (84.73%)
XCDYouTubeKit/XCDYouTubeVideoWebpage.m: 90 of 91 lines (98.90%)
Test Coverage: 92.01%
Slathered
```