### PR TITLE
Fix bad UTF-8 encoding issues

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -208,7 +208,8 @@ module Slather
     private :unsafe_profdata_llvm_cov_output
 
     def profdata_llvm_cov_output(binary_path, source_files)
-      unsafe_profdata_llvm_cov_output(binary_path, source_files).encode!('UTF-8', 'binary', :invalid => :replace, undef: :replace)
+      output = unsafe_profdata_llvm_cov_output(binary_path, source_files)
+      output.valid_encoding? ? output : output.encode!('UTF-8', 'binary', :invalid => :replace, undef: :replace)
     end
     private :profdata_llvm_cov_output
 

--- a/spec/fixtures/fixtures/fixtures.m
+++ b/spec/fixtures/fixtures/fixtures.m
@@ -3,7 +3,7 @@
 //  fixtures
 //
 //  Created by Mark Larsen on 6/24/14.
-//  Copyright (c) 2014 marklarr. All rights reserved.
+//  Copyright (c) 2014 marklarr 🌟. All rights reserved.
 //
 
 #import "fixtures.h"

--- a/spec/fixtures/fixtures_html/fixtures.m.html
+++ b/spec/fixtures/fixtures_html/fixtures.m.html
@@ -39,7 +39,7 @@
 </tr>
 <tr class="never">
 <td class="num">6</td>
-<td class="src"><pre><code class="objc">//  Copyright (c) 2014 marklarr. All rights reserved.</code></pre></td>
+<td class="src"><pre><code class="objc">//  Copyright (c) 2014 marklarr &#127775;. All rights reserved.</code></pre></td>
 <td class="coverage"></td>
 </tr>
 <tr class="never">

--- a/spec/slather/coverage_file_spec.rb
+++ b/spec/slather/coverage_file_spec.rb
@@ -64,7 +64,7 @@ describe Slather::CoverageFile do
 //  fixtures
 //
 //  Created by Mark Larsen on 6/24/14.
-//  Copyright (c) 2014 marklarr. All rights reserved.
+//  Copyright (c) 2014 marklarr 🌟. All rights reserved.
 //
 
 #import "fixtures.h"


### PR DESCRIPTION
Before this commit, the html report was displaying this:
//  Copyright (c) 2013-2016 C��dric Luthi. All rights reserved.

After this commit, the html report is displaying this:
//  Copyright (c) 2013-2016 Cédric Luthi. All rights reserved.

I added a 🌟 (Glowing Star, U+1F31F) in the fixtures to make sure it’s property encoded.

The problem was that valid UTF-8 was interpreted as "binary" and re-encoded as UTF-8, producing invalid output.
