### PR TITLE
Add teamcity as a CI service option

### DIFF
--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -213,7 +213,6 @@ module Slather
       private :coveralls_coverage_data
 
       def post
-        puts "Uploading coverage data to Coveralls..."
         f = File.open('coveralls_json_file', 'w+')
         begin
           f.write(coveralls_coverage_data)
@@ -228,8 +227,6 @@ module Slather
               error_message = curl_result_json["message"]
               raise StandardError, "Error while uploading coverage data to Coveralls. CI Service: #{ci_service} Message: #{error_message}"
             end
-
-            puts curl_result_json["url"]
           end
 
         rescue StandardError => e

--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -203,6 +203,8 @@ module Slather
               :source_files => coverage_files.map(&:as_json),
               :git => teamcity_git_info
             }.to_json
+          else
+            raise StandardError, "Environment variable `TC_BUILD_NUMBER` not set. Is this running on a teamcity build?"
           end
         else
           raise StandardError, "No support for ci named #{ci_service}"

--- a/spec/slather/coverage_service/coveralls_spec.rb
+++ b/spec/slather/coverage_service/coveralls_spec.rb
@@ -125,9 +125,14 @@ describe Slather::CoverageService::Coveralls do
         expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.coverage_files.map(&:as_json).to_json).at_path("source_files")
       end
 
-      it "should raise an error if there is no BUILD_ID" do
+      it "should raise an error if there is no TC_BUILD_NUMBER" do
         allow(fixtures_project).to receive(:teamcity_job_id).and_return(nil)
         expect { fixtures_project.send(:coveralls_coverage_data) }.to raise_error(StandardError)
+      end
+
+      it "should return the teamcity branch name" do
+        ENV['GIT_BRANCH'] = "master"
+        expect(fixtures_project.send(:teamcity_branch_name)).to eq("master")
       end
     end
   end

--- a/spec/slather/coverage_service/coveralls_spec.rb
+++ b/spec/slather/coverage_service/coveralls_spec.rb
@@ -131,8 +131,24 @@ describe Slather::CoverageService::Coveralls do
       end
 
       it "should return the teamcity branch name" do
+        git_branch = ENV['GIT_BRANCH']
         ENV['GIT_BRANCH'] = "master"
         expect(fixtures_project.send(:teamcity_branch_name)).to eq("master")
+        ENV['GIT_BRANCH'] = git_branch
+      end
+
+      it "should return the teamcity job id" do
+        teamcity_job_id = ENV['TC_BUILD_NUMBER']
+        ENV['TC_BUILD_NUMBER'] = "9182"
+        expect(fixtures_project.send(:teamcity_job_id)).to eq("9182")
+        ENV['TC_BUILD_NUMBER'] = teamcity_job_id
+      end
+
+      it "should return teamcity git info" do
+        git_branch = ENV['GIT_BRANCH']
+        ENV['GIT_BRANCH'] = "master"
+        expect(fixtures_project.send(:teamcity_git_info)).to eq({head: {id: `git log --format=%H -n 1 HEAD`.chomp, author_name: `git log --format=%an -n 1 HEAD`.chomp, author_email: `git log --format=%ae -n 1 HEAD`.chomp, message: `git log --format=%s -n 1 HEAD`.chomp }, branch: "master"})
+        ENV['GIT_BRANCH'] = git_branch
       end
     end
   end


### PR DESCRIPTION
When uploading to coveralls, want the option to set `teamcity` as the `ci_service`.

Also added some outputs to help see whats going on in the build log of teamcity.