### PR TITLE
Automatically ignore headers inside Xcode SDKs. Run Travis tests on Xcode 8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 script: bundle exec rake
-osx_image: xcode7.3
+osx_image: xcode8.2
 
 # Sets Travis to run the Ruby specs on OS X machines which are required to
 # build the native extensions of Xcodeproj.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Automatically ignore headers in Xcode platform SDKs.  
+  [ksuther](https://github.com/ksuther)
+  [#286](https://github.com/SlatherOrg/slather/pull/286)
+
 * Fix hanging `xcodebuild` invocation when getting derived data path.  
   [arthurtoper](https://github.com/arthurtoper)
   [#238](https://github.com/SlatherOrg/slather/pull/238), [#197](https://github.com/SlatherOrg/slather/issues/197), [#212](https://github.com/SlatherOrg/slather/issues/212), [#234](https://github.com/SlatherOrg/slather/issues/234)

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -144,24 +144,16 @@ module Slather
     private :supported_file_extensions
 
     def ignored?
-      ignore = false
-      platform_ignore_list.map do |ignore_suffix|
-        ignore = source_file_pathname.to_s.end_with? ignore_suffix
-        if ignore
-          break
-        end
+      # This indicates a llvm-cov coverage warning (occurs if a passed in source file 
+      # is not covered or with ccache in some cases).
+      ignore = source_file_pathname.to_s.end_with? "isn't covered."
+
+      if !ignore
+        # Ignore source files inside of platform SDKs
+        ignore = (/Xcode.*\.app\/Contents\/Developer\/Platforms/ =~ source_file_pathname.to_s) != nil
       end
+
       ignore ? ignore : super
     end
-
-    def platform_ignore_list
-      ["MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertionsImpl.h",
-        "MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/objc/objc.h",
-        "MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertions.h",
-        # This indicates a llvm-cov coverage warning (occurs if a passed in source file 
-        # is not covered or with ccache in some cases).
-        "isn't covered."]
-    end
-    private :platform_ignore_list
   end
 end

--- a/spec/slather/profdata_coverage_spec.rb
+++ b/spec/slather/profdata_coverage_spec.rb
@@ -91,13 +91,13 @@ describe Slather::ProfdataCoverageFile do
     it "should return the number of hits for a line in thousands as an integer" do
       result = profdata_coverage_file.coverage_for_line("  11.8k|   49|    return result;")
       expect(result).to eq(11800)
-      expect(result).to be_a(Fixnum)
+      expect(result).to be_a(Integer)
     end
 
     it "should return the number of hits for a line in millions as an integer" do
       result = profdata_coverage_file.coverage_for_line("  2.58M|   49|    return result;")
       expect(result).to eq(2580000)
-      expect(result).to be_a(Fixnum)
+      expect(result).to be_a(Integer)
     end
 
     it "should return the number of hits for an uncovered line" do


### PR DESCRIPTION
Three small changes:
- Stop using deprecated `Fixnum`
- Use a regex to filter out all files in Xcode platform SDKs. Eliminates the need for practically everyone to ignore `../*`
- Use Xcode 8.2 on Travis to keep up with the times