### PR TITLE
Use all framework binaries from bundle for coverage as well

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -362,6 +362,15 @@ module Slather
       end
     end
 
+    def find_framework_binaries_in_bundle(bundle_file)
+      return nil if not File.directory? bundle_file
+      Dir["#{bundle_file}/Frameworks/**/*.framework"].map do |framework_dir|
+        framework_name = File.basename(framework_dir, '.framework')
+        framework_binary = File.join(framework_dir, framework_name)
+        (File.file? framework_binary) ? framework_binary : nil
+      end.compact
+    end
+
     def find_binary_files
       binary_basename = load_option_array("binary_basename")
       found_binaries = []
@@ -418,6 +427,11 @@ module Slather
 
           if found_product and File.directory? found_product
             found_binary = find_binary_file_in_bundle(found_product)
+
+            found_framework_binaries = find_framework_binaries_in_bundle(found_product)
+            if found_framework_binaries
+              found_binaries.concat(found_framework_binaries)
+            end
           else
             found_binary = found_product
           end
@@ -443,6 +457,11 @@ module Slather
 
           if app_bundle != nil
             found_binary = find_binary_file_in_bundle(app_bundle)
+
+            found_framework_binaries = find_framework_binaries_in_bundle(found_product)
+            if found_framework_binaries
+              found_binaries.concat(found_framework_binaries)
+            end
           elsif matched_xctest_bundle != nil
             found_binary = find_binary_file_in_bundle(matched_xctest_bundle)
           elsif dynamic_lib_bundle != nil


### PR DESCRIPTION
For projects using frameworks for modularization purposes, slather won't generate proper coverage summary and reports — source files from frameworks won't be taken into account.

This PR is an attempt to fix that behavior. It is not ready to merge yet — it works, but wanted to discuss how to approach the `llvm-cov` warnings for frameworks (those are 3rd party included e.g. via cocoapods) that don't include x86 architecture or there is no coverage data for them: `error: Failed to load coverage: No object file for requested architecture` and `error: Failed to load coverage: No coverage data found`.

It might be a solution to add a setting with either ignored or selected framework names. Also, it might be OK to silence `llvm-cov` command that is run for those auto-detected frameworks.

What do you think?
