### PR TITLE
Xcode 8.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 script: bundle exec rake
-osx_image: xcode8.2
+osx_image: xcode8.3
 
 # Sets Travis to run the Ruby specs on OS X machines which are required to
 # build the native extensions of Xcodeproj.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Xcode 8.3 support.
+  [ksuther](https://github.com/ksuther)
+  [#291](https://github.com/SlatherOrg/slather/pull/291)
+
 * Automatically ignore headers in Xcode platform SDKs.  
   [ksuther](https://github.com/ksuther)
   [#286](https://github.com/SlatherOrg/slather/pull/286)

--- a/lib/slather/coverage_service/html_output.rb
+++ b/lib/slather/coverage_service/html_output.rb
@@ -157,13 +157,12 @@ module Slather
 
           cov.table(:class => "source_code") {
             cleaned_gcov_lines.each do |line|
-              data = line.split(line_number_separator, 3)
 
-              line_number = data[1].to_i
+              line_number = coverage_file.line_number_in_line(line)
               next unless line_number > 0
 
-              coverage_data = data[0].strip
-              line_data = [line_number, data[2], hits_for_coverage_line(coverage_file, line)]
+              line_source = line.split(line_number_separator, 3)[2]
+              line_data = [line_number, line_source, hits_for_coverage_line(coverage_file, line)]
               classes = ["num", "src", "coverage"]
 
               cov.tr(:class => class_for_coverage_line(coverage_file,line)) {

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "clamp", "~> 0.6"
   spec.add_dependency "xcodeproj", "< 2.0.0", ">= 0.20"
-  spec.add_dependency "nokogiri", "~> 1.6.3"
+  spec.add_dependency "nokogiri", "~> 1.7"
 
   ## Version 5 needs Ruby 2.2, so we specify an upper bound to stay compatible with system ruby
   spec.add_runtime_dependency 'activesupport', '>= 4.0.2', '< 5'

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "clamp", "~> 0.6"
   spec.add_dependency "xcodeproj", "< 2.0.0", ">= 0.20"
-  spec.add_dependency "nokogiri", "~> 1.7"
+  spec.add_dependency "nokogiri", "~> 1.6"
 
   ## Version 5 needs Ruby 2.2, so we specify an upper bound to stay compatible with system ruby
   spec.add_runtime_dependency 'activesupport', '>= 4.0.2', '< 5'

--- a/spec/slather/coverage_service/html_output_spec.rb
+++ b/spec/slather/coverage_service/html_output_spec.rb
@@ -186,29 +186,29 @@ describe Slather::CoverageService::HtmlOutput do
 
       allow(fixtures_project).to receive(:input_format).and_return("profdata")
       allow(fixtures_project).to receive(:profdata_llvm_cov_output).and_return("./spec/fixtures/fixtures/other_fixtures.m:
-     |    1|//
-     |    2|//  other_fixtures.m
-     |    3|//  fixtures
-     |    4|//
-     |    5|//  Created by Mark Larsen on 6/24/14.
-     |    6|//  Copyright (c) 2014 marklarr. All rights reserved.
-     |    7|//
-     |    8|
-     |    9|#import \"other_fixtures.h\"
-     |   10|
-     |   11|@implementation other_fixtures
-     |   12|
-     |   13|- (void)testedMethod
-    1|   14|{
-    1|   15|    NSLog(@\"tested\");
-    1|   16|}
-     |   17|
-     |   18|- (void)untestedMethod
-    0|   19|{
-    0|   20|    NSLog(@\"untested\");
-    0|   21|}
-     |   22|
-     |   23|@end
+    1|     |//
+    2|     |//  other_fixtures.m
+    3|     |//  fixtures
+    4|     |//
+    5|     |//  Created by Mark Larsen on 6/24/14.
+    6|     |//  Copyright (c) 2014 marklarr. All rights reserved.
+    7|     |//
+    8|     |
+    9|     |#import \"other_fixtures.h\"
+   10|     |
+   11|     |@implementation other_fixtures
+   12|     |
+   13|     |- (void)testedMethod
+   14|    1|{
+   15|    1|    NSLog(@\"tested\");
+   16|    1|}
+   17|     |
+   18|     |- (void)untestedMethod
+   19|    0|{
+   20|    0|    NSLog(@\"untested\");
+   21|    0|}
+   22|     |
+   23|     |@end
 ")
       fixtures_project.post
 


### PR DESCRIPTION
llvm-cov in Xcode 8.3 arbitrarily swapped the line numbers and coverage count. This detects the version of llvm-cov and behaves accordingly.

It'd be good to get a set of eyes on this and do a release if nobody runs into trouble, since Xcode 8.3 is now out (@neonichu in particular, since you've been doing the releases :heart:).