### PR TITLE
add configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   [ksuther](https://github.com/ksuther)
   [#291](https://github.com/SlatherOrg/slather/pull/291)
 
+* Add `--configuration` option
+  [thasegaw](https://github.com/thasegaw)
+  [#xxx](https://github.com/slatherOrg/slather/pull/xxx)
+
 * Automatically ignore headers in Xcode platform SDKs.  
   [ksuther](https://github.com/ksuther)
   [#286](https://github.com/SlatherOrg/slather/pull/286)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## master
 
+* Add `--configuration` option
+  [thasegaw](https://github.com/thasegaw)
+  [#xxx](https://github.com/slatherOrg/slather/pull/294)
+
 ## v2.4.0
 
 * Xcode 8.3 support.
   [ksuther](https://github.com/ksuther)
   [#291](https://github.com/SlatherOrg/slather/pull/291)
-
-* Add `--configuration` option
-  [thasegaw](https://github.com/thasegaw)
-  [#xxx](https://github.com/slatherOrg/slather/pull/xxx)
 
 * Automatically ignore headers in Xcode platform SDKs.  
   [ksuther](https://github.com/ksuther)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Add `--configuration` option
   [thasegaw](https://github.com/thasegaw)
-  [#xxx](https://github.com/slatherOrg/slather/pull/294)
+  [#294](https://github.com/slatherOrg/slather/pull/294)
 
 ## v2.4.0
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ If you use a workspace in Xcode you need to specify it:
 $ slather coverage -s --scheme YourXcodeSchemeName --workspace path/to/workspace.xcworkspace path/to/project.xcodeproj
 ```
 
-If you use different configuration that is set at test target in Xcode you need to specify it: 
+If you use a different configuration for your tests: 
 
 ```sh
-$ slather coverage -s --scheme YourXcodeSchemeName --configuration YourBuiltConfigurationNameForTest
+$ slather coverage -s --scheme YourXcodeSchemeName --configuration YourBuildConfigurationName
 ```
 
 ### Setup for Xcode 5 and 6

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ If you use a workspace in Xcode you need to specify it:
 $ slather coverage -s --scheme YourXcodeSchemeName --workspace path/to/workspace.xcworkspace path/to/project.xcodeproj
 ```
 
+If you use different configuration that is set at test target in Xcode you need to specify it: 
+
+```sh
+$ slather coverage -s --scheme YourXcodeSchemeName --configuration YourBuiltConfigurationNameForTest
+```
+
 ### Setup for Xcode 5 and 6
 
 Run this command to enable the `Generate Test Coverage` and `Instrument Program Flow` flags for your project:
@@ -75,6 +81,7 @@ Make a `.slather.yml` file:
 coverage_service: cobertura_xml
 xcodeproj: path/to/project.xcodeproj
 scheme: YourXcodeSchemeName
+configuration: TestedConfiguration
 source_directory: path/to/sources/to/include
 output_directory: path/to/xml_report
 ignore:

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -24,6 +24,7 @@ class CoverageCommand < Clamp::Command
 
   option ["--input-format"], "INPUT_FORMAT", "Input format (gcov, profdata)"
   option ["--scheme"], "SCHEME", "The scheme for which the coverage was generated"
+  option ["--configuration"], "CONFIGURATION", "The configuration for test that the project was set"
   option ["--workspace"], "WORKSPACE", "The workspace that the project was built in"
   option ["--binary-file"], "BINARY_FILE", "The binary file against the which the coverage will be run", :multivalued => true
   option ["--binary-basename"], "BINARY_BASENAME", "Basename of the file against which the coverage will be run", :multivalued => true
@@ -42,6 +43,7 @@ class CoverageCommand < Clamp::Command
     setup_verbose_mode
     setup_input_format
     setup_scheme
+    setup_configuration
     setup_workspace
     setup_binary_file
     setup_binary_basename
@@ -127,6 +129,10 @@ class CoverageCommand < Clamp::Command
 
   def setup_scheme
     project.scheme = scheme
+  end
+
+  def setup_configuration
+    project.configuration = configuration
   end
 
   def setup_workspace

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -52,7 +52,7 @@ module Slather
 
     attr_accessor :build_directory, :ignore_list, :ci_service, :coverage_service, :coverage_access_token, :source_directory,
       :output_directory, :xcodeproj, :show_html, :verbose_mode, :input_format, :scheme, :workspace, :binary_file, :binary_basename, :source_files,
-      :decimals, :llvm_version
+      :decimals, :llvm_version, :configuration
 
     alias_method :setup_for_coverage, :slather_setup_for_coverage
 
@@ -230,6 +230,7 @@ module Slather
     def configure
       begin
         configure_scheme
+        configure_configuration
         configure_workspace
         configure_build_directory
         configure_ignore_list
@@ -298,6 +299,10 @@ module Slather
 
     def configure_scheme
       self.scheme ||= self.class.yml["scheme"] if self.class.yml["scheme"]
+    end
+
+    def configure_configuration
+      self.configuration ||= self.class.yml["configuration"] if self.class.yml["configuration"]
     end
 
     def configure_decimals
@@ -395,7 +400,11 @@ module Slather
 
         xcscheme = Xcodeproj::XCScheme.new(xcscheme_path)
 
-        configuration = xcscheme.test_action.build_configuration
+        if self.configuration
+          configuration = self.configuration
+        else
+          configuration = xcscheme.test_action.build_configuration
+        end
 
         search_list = binary_basename || find_buildable_names(xcscheme)
 

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -242,6 +242,7 @@ describe Slather::Project do
       expect(unstubbed_project).to receive(:configure_coverage_service)
       expect(unstubbed_project).to receive(:configure_input_format)
       expect(unstubbed_project).to receive(:configure_scheme)
+      expect(unstubbed_project).to receive(:configure_configuration)
       expect(unstubbed_project).to receive(:configure_workspace)
       unstubbed_project.configure
     end
@@ -322,6 +323,21 @@ describe Slather::Project do
       fixtures_project.output_directory = "/already/set"
       fixtures_project.configure_output_directory
       expect(fixtures_project.output_directory).to eq("/already/set")
+    end
+  end
+
+  describe "#configure_configuration" do
+    it "should set the configuration if it has been provided in the yml and has not already been set" do
+      allow(Slather::Project).to receive(:yml).and_return({"configuration" => "Release"})
+      fixtures_project.configure_configuration
+      expect(fixtures_project.configuration).to eq("Release")
+    end
+
+    it "should not set the configuration if it has already been set" do
+      allow(Slather::Project).to receive(:yml).and_return({"configuration" => "Release"})
+      fixtures_project.configuration = "Debug"
+      fixtures_project.configure_configuration
+      expect(fixtures_project.configuration).to eq("Debug")
     end
   end
 

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -567,4 +567,34 @@ describe Slather::Project do
       expect(decimal_f('50.00000')).to eq('50.0')
     end
   end
+
+  describe '#find_binary_files' do
+    let(:configuration) { 'Debug' }
+    let(:project_root) { Pathname("./").realpath }
+    let(:coverage_dir) { "#{project_root}/spec/DerivedData/DerivedData/Build/Intermediates/CodeCoverage" }
+    let(:search_dir) { "#{coverage_dir}/Products/#{configuration}*/fixtures*" }
+    let(:binary_file) { "#{coverage_dir}/Products/#{configuration}-iphonesimulator/fixtures.app/fixtures" }
+
+    before do
+      allow(fixtures_project).to receive(:scheme).and_return("fixtures")
+      allow(fixtures_project).to receive(:workspace).and_return("fixtures.xcworkspace")
+      allow(fixtures_project).to receive(:binary_basename).and_return(["fixtures"])
+      allow(fixtures_project).to receive(:profdata_coverage_dir).and_return(coverage_dir)
+      allow(Dir).to receive(:[]).with(search_dir).and_return([binary_file])
+    end
+
+    context 'aaa' do    
+      it 'should set configuration from xcsheme ' do
+        expect(fixtures_project.find_binary_files).to eq([binary_file])
+      end
+    end
+
+    context 'bbb' do
+      let(:configuration) { 'Release' }
+      it 'should set configuration from option' do
+        fixtures_project.configuration = configuration
+        expect(fixtures_project.find_binary_files).to eq([binary_file])
+      end
+    end
+  end
 end

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -583,18 +583,14 @@ describe Slather::Project do
       allow(Dir).to receive(:[]).with(search_dir).and_return([binary_file])
     end
 
-    context 'aaa' do    
-      it 'should set configuration from xcsheme ' do
-        expect(fixtures_project.find_binary_files).to eq([binary_file])
-      end
+    it 'should set configuration from xcsheme ' do
+      expect(fixtures_project.find_binary_files).to eq([binary_file])
     end
 
-    context 'bbb' do
-      let(:configuration) { 'Release' }
-      it 'should set configuration from option' do
-        fixtures_project.configuration = configuration
-        expect(fixtures_project.find_binary_files).to eq([binary_file])
-      end
+    let(:configuration) { 'Release' }
+    it 'should set configuration from option' do
+      fixtures_project.configuration = configuration
+      expect(fixtures_project.find_binary_files).to eq([binary_file])
     end
   end
 end

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -583,14 +583,18 @@ describe Slather::Project do
       allow(Dir).to receive(:[]).with(search_dir).and_return([binary_file])
     end
 
-    it 'should set configuration from xcsheme ' do
-      expect(fixtures_project.find_binary_files).to eq([binary_file])
+    context 'load configuration from xcsheme' do
+      it "search binary from 'Products/Debug*'" do
+        expect(fixtures_project.find_binary_files).to eq([binary_file])
+      end
     end
 
-    let(:configuration) { 'Release' }
-    it 'should set configuration from option' do
-      fixtures_project.configuration = configuration
-      expect(fixtures_project.find_binary_files).to eq([binary_file])
+    context 'load configuration from option' do
+      let(:configuration) { 'Release' }
+      it "search binary from 'Products/Release*'" do
+        fixtures_project.configuration = configuration
+        expect(fixtures_project.find_binary_files).to eq([binary_file])
+      end
     end
   end
 end


### PR DESCRIPTION
`No product binary found` error occurs when a unit test is executed using a configuration value that is different from the value set in its Xcode project.

### example

#### configuration setting for "sample_demo" scheme in Xcode
`Debug`

#### Fastfile
```
lane :unittest do
  scan(
    clean: true,
    workspace: "sample.xcworkspace",
    scheme: "sample_demo",
    configuration: "sample_configuration",
    code_coverage: true
  )
end
```

#### execute `slather` in command line
##### before
```
$ slather coverage --scheme sample_demo --workspace sample.xcworkspace -v sample.xcodeproj
Slathering...
No product binary found in /Users/testuser/Library/Developer/Xcode/DerivedData/sample_demo-drulcbjceghbnoeyoatkqldemoja/Build/Intermediates/CodeCoverage.

    Are you sure your project is generating coverage? Make sure you enable code coverage in the Test section of your Xcode scheme.
    Did you specify your Xcode scheme? (--scheme or 'scheme' in .slather.yml)
    If you're using a workspace, did you specify it? (--workspace or 'workspace' in .slather.yml)

/Users/testuser/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/slather-2.3.1/lib/slather/project.rb:469:in `find_binary_files': No product binary found in /Users/testuser/Library/Developer/Xcode/DerivedData/sample_demo-drulcbjceghbnoeyoatkqldemoja/Build/Intermediates/CodeCoverage. (StandardError)
    from /Users/testuser/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/slather-2.3.1/lib/slather/project.rb:350:in `configure_binary_file'
    from /Users/testuser/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/slather-2.3.1/lib/slather/project.rb:242:in `configure'
    from /Users/testuser/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/slather-2.3.1/lib/slather/command/coverage_command.rb:53:in `execute'
    from /Users/testuser/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/clamp-0.6.5/lib/clamp/command.rb:67:in `run'
    from /Users/testuser/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/clamp-0.6.5/lib/clamp/subcommand/execution.rb:11:in `execute'
    from /Users/testuser/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/clamp-0.6.5/lib/clamp/command.rb:67:in `run'
    from /Users/testuser/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/clamp-0.6.5/lib/clamp/command.rb:132:in `run'
    from /Users/testuser/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/slather-2.3.1/bin/slather:17:in `<top (required)>'
    from /Users/testuser/.rbenv/versions/2.3.1/bin/slather:23:in `load'
    from /Users/testuser/.rbenv/versions/2.3.1/bin/slather:23:in `<main>'

$ ls /Users/testuser/Library/Developer/Xcode/DerivedData/sample_demo-drulcbjceghbnoeyoatkqldemoja/Build/Intermediates/CodeCoverage/Products
sample_configuration-iphonesimulator             Release-iphonesimulator
sample_configuration-watchsimulator
```

#### after
```
$ slather coverage --scheme sample_demo --workspace sample.xcworkspace --configuration sample_configuration -v sample.xcodeproj
Slathering...

Processing coverage file: /Users/testuser/Library/Developer/Xcode/DerivedData/sample_demo-drulcbjceghbnoeyoatkqldemoja/Build/Intermediates/CodeCoverage/Coverage.profdata
Against binary files:
    /Users/testuser/Library/Developer/Xcode/DerivedData/sample_demo-drulcbjceghbnoeyoatkqldemoja/Build/Intermediates/CodeCoverage/Products/sample_configuration-iphonesimulator/sample.app/sample

.
.

Test Coverage: 10.54%
Slathered
```