### PR TITLE
Don't use Spotlight for Xcode version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   [thasegaw](https://github.com/thasegaw)
   [#294](https://github.com/slatherOrg/slather/pull/294)
 
+* Fix misdetection of Xcode version if Spotlight hasn't indexed Xcode yet
+  [ksuther](https://github.com/ksuther)
+  [#298](https://github.com/slatherOrg/slather/pull/298)
+
 ## v2.4.0
 
 * Xcode 8.3 support.

--- a/lib/slather.rb
+++ b/lib/slather.rb
@@ -10,6 +10,7 @@ require 'slather/coverage_service/hardcover'
 require 'slather/coverage_service/gutter_json_output'
 require 'slather/coverage_service/simple_output'
 require 'slather/coverage_service/html_output'
+require 'cfpropertylist'
 
 module Slather
 
@@ -21,7 +22,8 @@ module Slather
 
   def self.xcode_version
     xcode_path = `xcode-select -p`.strip
-    xcode_version = `mdls -name kMDItemVersion -raw #{xcode_path.shellescape}/../..`.strip
+    plist = CFPropertyList::List.new(:file => File.join(xcode_path, '..', 'Info.plist'))
+    xcode_version = CFPropertyList.native_types(plist.value)["CFBundleShortVersionString"]
     xcode_version.split('.').map(&:to_i)
   end
 

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -27,19 +27,12 @@ module Xcodeproj
 
       # Patch xcschemes too
       if format == :clang
-        if Gem::Requirement.new('>= 0.28.2') =~ Gem::Version.new(Xcodeproj::VERSION)
-          # @todo This will require to bump the xcodeproj dependency to >= 0.28.2
-          # (which would require to bump cocoapods too)
-          schemes_path = Xcodeproj::XCScheme.shared_data_dir(self.path)
-          Xcodeproj::Project.schemes(self.path).each do |scheme_name|
-            xcscheme_path = "#{schemes_path + scheme_name}.xcscheme"
-            xcscheme = Xcodeproj::XCScheme.new(xcscheme_path)
-            xcscheme.test_action.xml_element.attributes['codeCoverageEnabled'] = 'YES'
-            xcscheme.save_as(self.path, scheme_name)
-          end
-        else
-          # @todo In the meantime, simply inform the user to do it manually
-          puts %Q(Ensure you enabled "Gather coverage data" in each of your scheme's Test action)
+        schemes_path = Xcodeproj::XCScheme.shared_data_dir(self.path)
+        Xcodeproj::Project.schemes(self.path).each do |scheme_name|
+          xcscheme_path = "#{schemes_path + scheme_name}.xcscheme"
+          xcscheme = Xcodeproj::XCScheme.new(xcscheme_path)
+          xcscheme.test_action.xml_element.attributes['codeCoverageEnabled'] = 'YES'
+          xcscheme.save_as(self.path, scheme_name)
         end
       end
     end

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "clamp", "~> 0.6"
   spec.add_dependency "xcodeproj", "~> 1.4"
   spec.add_dependency "nokogiri", "~> 1.6"
+  spec.add_dependency "CFPropertyList", "~> 2.2"
 
   ## Version 5 needs Ruby 2.2, so we specify an upper bound to stay compatible with system ruby
   spec.add_runtime_dependency 'activesupport', '>= 4.0.2', '< 5'

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -23,12 +23,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.4"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "pry", "~> 0.9"
-  spec.add_development_dependency "cocoapods", "~> 1.0"
+  spec.add_development_dependency "cocoapods", "~> 1.2"
   spec.add_development_dependency "json_spec", "~> 1.1.4"
   spec.add_development_dependency "equivalent-xml", "~> 0.5.1"
 
   spec.add_dependency "clamp", "~> 0.6"
-  spec.add_dependency "xcodeproj", "< 2.0.0", ">= 0.20"
+  spec.add_dependency "xcodeproj", "~> 1.4"
   spec.add_dependency "nokogiri", "~> 1.6"
 
   ## Version 5 needs Ruby 2.2, so we specify an upper bound to stay compatible with system ruby


### PR DESCRIPTION
slather was using mdls/Spotlight to detect Xcode's version. If mdls returned (null) then the Xcode version was detected as 0, which would cause it to use the gcov path by default.

This changes it so we read the Xcode version out of the plist directly.

This should fix issues like #297 where Spotlight hasn't indexed yet. It will likely fix issues like #262 as well.