### PR TITLE
Better verbose message when no binaries are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   [ksuther](https://github.com/ksuther)
   [#298](https://github.com/slatherOrg/slather/pull/298)
 
+* Better verbose message when no binaries are found  
+  [ksuther](https://github.com/ksuther)
+  [#300](https://github.com/slatherOrg/slather/pull/300)
+
 ## v2.4.0
 
 * Xcode 8.3 support.

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -246,9 +246,13 @@ module Slather
 
       if self.verbose_mode
         puts "\nProcessing coverage file: #{profdata_file}"
-        puts "Against binary files:"
-        self.binary_file.each do |binary_file|
-          puts "\t#{binary_file}"
+        if self.binary_file
+          puts "Against binary files:"
+          self.binary_file.each do |binary_file|
+            puts "\t#{binary_file}"
+          end
+        else
+          puts "No binary files found."
         end
         puts "\n"
       end

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -519,6 +519,21 @@ describe Slather::Project do
 
       fixtures_project.send(:configure)
     end
+
+    it "should print error when no binaries found" do
+      allow(fixtures_project).to receive(:binary_file).and_return(nil)
+
+      project_root = Pathname("./").realpath
+
+      ["\nProcessing coverage file: #{project_root}/spec/DerivedData/libfixtures/Build/Intermediates/CodeCoverage/Coverage.profdata",
+       "No binary files found.",
+       "\n",
+      ].each do |line|
+        expect(fixtures_project).to receive(:puts).with(line)
+      end
+
+      fixtures_project.send(:configure)
+    end
   end
 
   describe "#source_files" do


### PR DESCRIPTION
Print a message saying no binary files were found instead of throwing an exception.