### PR TITLE
Added help message for configuration

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -56,7 +56,7 @@ module Slather
     end
 
     def failure_help_string
-      "\n\tAre you sure your project is generating coverage? Make sure you enable code coverage in the Test section of your Xcode scheme.\n\tDid you specify your Xcode scheme? (--scheme or 'scheme' in .slather.yml)\n\tIf you're using a workspace, did you specify it? (--workspace or 'workspace' in .slather.yml)"
+      "\n\tAre you sure your project is generating coverage? Make sure you enable code coverage in the Test section of your Xcode scheme.\n\tDid you specify your Xcode scheme? (--scheme or 'scheme' in .slather.yml)\n\tIf you use different configuration that is set at test target in Xcode, did you specify it?\n\tIf you're using a workspace, did you specify it? (--workspace or 'workspace' in .slather.yml)"
     end
 
     def derived_data_path

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -56,7 +56,7 @@ module Slather
     end
 
     def failure_help_string
-      "\n\tAre you sure your project is generating coverage? Make sure you enable code coverage in the Test section of your Xcode scheme.\n\tDid you specify your Xcode scheme? (--scheme or 'scheme' in .slather.yml)\n\tIf you use different configuration that is set at test target in Xcode, did you specify it? (--configuration or 'configuration' in .slather.yml)\n\tIf you're using a workspace, did you specify it? (--workspace or 'workspace' in .slather.yml)"
+      "\n\tAre you sure your project is generating coverage? Make sure you enable code coverage in the Test section of your Xcode scheme.\n\tDid you specify your Xcode scheme? (--scheme or 'scheme' in .slather.yml)\n\tIf you're using a workspace, did you specify it? (--workspace or 'workspace' in .slather.yml)\n\tIf you use a different Xcode configuration, did you specify it? (--configuration or 'configuration' in .slather.yml)"
     end
 
     def derived_data_path

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -56,7 +56,7 @@ module Slather
     end
 
     def failure_help_string
-      "\n\tAre you sure your project is generating coverage? Make sure you enable code coverage in the Test section of your Xcode scheme.\n\tDid you specify your Xcode scheme? (--scheme or 'scheme' in .slather.yml)\n\tIf you use different configuration that is set at test target in Xcode, did you specify it?\n\tIf you're using a workspace, did you specify it? (--workspace or 'workspace' in .slather.yml)"
+      "\n\tAre you sure your project is generating coverage? Make sure you enable code coverage in the Test section of your Xcode scheme.\n\tDid you specify your Xcode scheme? (--scheme or 'scheme' in .slather.yml)\n\tIf you use different configuration that is set at test target in Xcode, did you specify it? (--configuration or 'configuration' in .slather.yml)\n\tIf you're using a workspace, did you specify it? (--workspace or 'workspace' in .slather.yml)"
     end
 
     def derived_data_path


### PR DESCRIPTION
I forgot to fix the help message for configuration option.

#### before
```
$ slather version
slather 2.4.1

$ slather coverage --scheme sample --workspace sample.xcworkspace -v sample.xcodeproj
Slathering...
No product binary found in /Users/sampleuser/Library/Developer/Xcode/DerivedData/sample-drulcbjceghbnoeyoatkqldemoja/Build/Intermediates/CodeCoverage.

	Are you sure your project is generating coverage? Make sure you enable code coverage in the Test section of your Xcode scheme.
	Did you specify your Xcode scheme? (--scheme or 'scheme' in .slather.yml)
	If you're using a workspace, did you specify it? (--workspace or 'workspace' in .slather.yml)
```

#### after
```
$ slather coverage --scheme sample --workspace sample.xcworkspace -v sample.xcodeproj
Slathering...
No product binary found in /Users/sampleuser/Library/Developer/Xcode/DerivedData/sample-drulcbjceghbnoeyoatkqldemoja/Build/Intermediates/CodeCoverage.

	Are you sure your project is generating coverage? Make sure you enable code coverage in the Test section of your Xcode scheme.
	Did you specify your Xcode scheme? (--scheme or 'scheme' in .slather.yml)
	If you use different configuration that is set at test target in Xcode, did you specify it? (--configuration or 'configuration' in .slather.yml)
	If you're using a workspace, did you specify it? (--workspace or 'workspace' in .slather.yml)
```