### PR TITLE
Jenkins_branch_name updated for Jenkins' pipeline support

### DIFF
--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -37,7 +37,7 @@ module Slather
       private :jenkins_job_id
 
       def jenkins_branch_name
-        branch_name = ENV['GIT_BRANCH']
+        branch_name = ENV['GIT_BRANCH'] || ENV['BRANCH_NAME']
         if branch_name.include? 'origin/'
           branch_name[7...branch_name.length]
         else


### PR DESCRIPTION
I received the following crash:

```Users/Shared/Jenkins/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/slather-2.4.1/lib/slather/coverage_service/coveralls.rb:41:in `jenkins_branch_name': undefined method `include?' for nil:NilClass (NoMethodError)```

Seems like Slather is currently using GIT_BRANCH_NAME to detect the current branch name, which is unavailable in the Pipeline flow, as mentioned in this [jenkins issue](https://issues.jenkins-ci.org/browse/JENKINS-35230?focusedCommentId=288295&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-288295).

This PR allows Slather to select either of the 2, with GIT_BRANCH being checked first.