### PR TITLE
Retrieving LLVM version is now backwards compatible with Xcode 7

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -236,7 +236,7 @@ module Slather
         configure_binary_file
         configure_decimals
 
-        self.llvm_version = `xcrun llvm-cov --version`.match(/Apple LLVM version ([\d\.]+)/).captures[0]
+        self.llvm_version = `xcrun llvm-cov --version`.match(/LLVM version ([\d\.]+)/).captures[0]
       rescue => e
         puts e.message
         puts failure_help_string


### PR DESCRIPTION
This addresses issue #306 and fixes Slather for Xcode 7 builds

The main issue is line 239 (https://github.com/SlatherOrg/slather/blob/master/lib/slather/project.rb#L239) of `project.rb`, which parses the LLVM version from the output of `xcrun llvm-cov --version`. If the version can't be parsed, the match array is null, and the `captures` method fails. The stack trace returns:

    /usr/local/lib/ruby/gems/2.4.0/gems/slather-2.4.1/lib/slather/project.rb:239:in `configure': undefined method `captures' for nil:NilClass (NoMethodError)
	from /usr/local/lib/ruby/gems/2.4.0/gems/slather-2.4.1/lib/slather/command/coverage_command.rb:53:in `execute'
	from /usr/local/lib/ruby/gems/2.4.0/gems/clamp-0.6.5/lib/clamp/command.rb:67:in `run'
	from /usr/local/lib/ruby/gems/2.4.0/gems/clamp-0.6.5/lib/clamp/subcommand/execution.rb:11:in `execute'
	from /usr/local/lib/ruby/gems/2.4.0/gems/clamp-0.6.5/lib/clamp/command.rb:67:in `run'
	from /usr/local/lib/ruby/gems/2.4.0/gems/clamp-0.6.5/lib/clamp/command.rb:132:in `run'
	from /usr/local/lib/ruby/gems/2.4.0/gems/slather-2.4.1/bin/slather:17:in `<top (required)>'
	from /usr/local/bin/slather:22:in `load'
	from /usr/local/bin/slather:22:in `<main>'

When Xcode 7 is installed, or selected as the active Xcode app, running `xcrun llvm-cov --version` gives the following output:

    bash-3.2$ xcrun llvm-cov --version
    LLVM (http://llvm.org/):
    LLVM version 7.3.0
    Optimized build.
    Built Apr  4 2016 (19:08:39).
    Default target: x86_64-apple-darwin16.5.0
    Host CPU: ivybridge`

When Xcode 8 is active, the command generates the following:

    $ xcrun llvm-cov --version
    Apple LLVM version 8.1.0 (clang-802.0.42)
    Optimized build.
    Default target: x86_64-apple-darwin16.5.0
    Host CPU: skylake

The obvious difference here is the line containing the LLVM version information. Xcode 8 and beyond prefix this line with `Apple`, which is what the regex current checks for. The change to parse the LLVM version was only added 2 months ago, so Xcode 7 may have been an afterthought at the time. Ideally, there would be a better function to parse the version string, but simply removing the `Apple` prefix from the regex is good enough to fix the issue.