### PR TITLE
Converted raise StandardError usage to exit() with unique codes. Curr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,34 @@ Include the `--workspace` argument or add `workspace` to `.slather.yml` if you b
 $ slather coverage --html --scheme YourXcodeSchemeName --workspace path/to/workspace.xcworkspace path/to/project.xcodeproj
 ```
 
+## Exits
+| Code | Reason |
+|:----:| ------ |
+| 0 | Success |
+| 100 | Missing xcodeproject |
+| 101 | Unsupported input format |
+| 102 | No coverage files found |
+| 103 | No coverage directory |
+| 104 | Build directory does not exists |
+| 105 | No Coverage.profdata files |
+| 106 | No binary file found |
+| 107 | Missing scheme |
+| 108 | No product binary found |
+| 200 | Access token set. Not needed |
+| 201 | Access token not set. Required. |
+| 202 | TRAVIS_JOB_ID not set. |
+| 203 | CIRCLE_BUILD_NUM not set. |
+| 204 | BUILD_ID not set. |
+| 205 | BUILDKITE_BUILD_NUMBER not set. |
+| 206 | TC_BUILD_NUMBER not set. |
+| 207 | No support for given ci. |
+| 208 | Error uploading data to Coveralls. |
+| 300 | Missing xcodeproject |
+| 400 | Missing xcodeproject |
+| 500 | BUILD_NUMBER and JOB_NAME are not set. Jenkins? |
+| 501 | No support for given ci. |
+| 502 | No hardcover_base_url configured |
+
 ## Contributing
 
 We’d love to see your ideas for improving this library! The best way to contribute is by submitting a pull request. We’ll do our best to respond to your patch as soon as possible. You can also submit a [new GitHub issue](https://github.com/SlatherOrg/slather/issues/new) if you find bugs or have questions. :octocat:

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -99,7 +99,8 @@ class CoverageCommand < Clamp::Command
       if xcodeproj_path_to_open
         project = Slather::Project.open(xcodeproj_path_to_open)
       else
-        raise StandardError, "Must provide an xcodeproj either via the 'slather [SUBCOMMAND] [PROJECT].xcodeproj' command or through .slather.yml"
+        STDERR.puts 'Must provide an xcodeproj either via the "slather [SUBCOMMAND] [PROJECT].xcodeproj" command or through .slather.yml'
+        exit(300)
       end
     end
   end

--- a/lib/slather/command/setup_command.rb
+++ b/lib/slather/command/setup_command.rb
@@ -6,7 +6,8 @@ class SetupCommand < Clamp::Command
   def execute
     xcodeproj_path_to_open = xcodeproj_path || Slather::Project.yml["xcodeproj"]
     unless xcodeproj_path_to_open
-      raise StandardError, "Must provide a .xcodeproj either via the 'slather [SUBCOMMAND] [PROJECT].xcodeproj' command or through .slather.yml"
+      STDERR.puts 'Must provide a .xcodeproj either via the "slather [SUBCOMMAND] [PROJECT].xcodeproj" command or through .slather.yml'
+      exit(400)
     end
     project = Slather::Project.open(xcodeproj_path_to_open)
     project.setup_for_coverage(format ? format.to_sym : :auto)

--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -125,7 +125,8 @@ module Slather
             if ci_service == :travis_ci
               
               if coverage_access_token.to_s.strip.length > 0
-                raise StandardError, "Access token is set. Uploading coverage data for public repositories doesn't require an access token."
+                STDERR.puts 'Access token is set. Uploading coverage data for public repositories doesn\'t require an access token.'
+                exit(200)
               end
 
               {
@@ -136,7 +137,8 @@ module Slather
             elsif ci_service == :travis_pro              
 
               if coverage_access_token.to_s.strip.length == 0
-                raise StandardError, "Access token is not set. Uploading coverage data for private repositories requires an access token."
+                STDERR.puts 'Access token is not set. Uploading coverage data for private repositories requires an access token.'
+                exit(201)
               end
 
               {
@@ -147,7 +149,8 @@ module Slather
               }.to_json
             end
           else
-            raise StandardError, "Environment variable `TRAVIS_JOB_ID` not set. Is this running on a travis build?"
+            STDERR.puts "Environment variable `TRAVIS_JOB_ID` not set. Is this running on a travis build?"
+            exit(202)
           end
         elsif ci_service == :circleci
           if circleci_job_id
@@ -166,7 +169,8 @@ module Slather
 
             coveralls_hash.to_json
           else
-            raise StandardError, "Environment variable `CIRCLE_BUILD_NUM` not set. Is this running on a circleci build?"
+            STDERR.puts "Environment variable `CIRCLE_BUILD_NUM` not set. Is this running on a circleci build?"
+            exit(203)
           end
         elsif ci_service == :jenkins
           if jenkins_job_id
@@ -178,7 +182,8 @@ module Slather
               git: jenkins_git_info
             }.to_json
           else
-            raise StandardError, "Environment variable `BUILD_ID` not set. Is this running on a jenkins build?"
+            STDERR.puts "Environment variable `BUILD_ID` not set. Is this running on a jenkins build?"
+            exit(204)
           end
         elsif ci_service == :buildkite
           if buildkite_job_id
@@ -192,7 +197,8 @@ module Slather
               :service_pull_request => buildkite_pull_request
             }.to_json
           else
-            raise StandardError, "Environment variable `BUILDKITE_BUILD_NUMBER` not set. Is this running on a buildkite build?"
+            STDERR.puts "Environment variable `BUILDKITE_BUILD_NUMBER` not set. Is this running on a buildkite build?"
+            exit(205)
           end
         elsif ci_service == :teamcity
           if teamcity_job_id
@@ -204,10 +210,12 @@ module Slather
               :git => teamcity_git_info
             }.to_json
           else
-            raise StandardError, "Environment variable `TC_BUILD_NUMBER` not set. Is this running on a teamcity build?"
+            STDERR.puts "Environment variable `TC_BUILD_NUMBER` not set. Is this running on a teamcity build?"
+            exit(206)
           end
         else
-          raise StandardError, "No support for ci named #{ci_service}"
+          STDERR.puts "No support for ci named #{ci_service}"
+          exit(207)
         end
       end
       private :coveralls_coverage_data
@@ -225,13 +233,11 @@ module Slather
 
             if curl_result_json["error"]
               error_message = curl_result_json["message"]
-              raise StandardError, "Error while uploading coverage data to Coveralls. CI Service: #{ci_service} Message: #{error_message}"
+              FileUtils.rm(f)
+              STDERR.puts "Error while uploading coverage data to Coveralls. CI Service: #{ci_service} Message: #{error_message}"
+              exit(208)
             end
           end
-
-        rescue StandardError => e
-          FileUtils.rm(f)
-          raise e
         end
         FileUtils.rm(f)
       end

--- a/lib/slather/coverage_service/hardcover.rb
+++ b/lib/slather/coverage_service/hardcover.rb
@@ -26,10 +26,12 @@ module Slather
               :source_files => coverage_files.map(&:as_json)
             }.to_json
           else
-            raise StandardError, "Environment variables `BUILD_NUMBER` and `JOB_NAME` are not set. Is this running on a Jenkins build?"
+            STDERR.puts 'Environment variables `BUILD_NUMBER` and `JOB_NAME` are not set. Is this running on a Jenkins build?'
+            exit(500)
           end
         else
-          raise StandardError, "No support for ci named #{ci_service}"
+          STDERR.puts "No support for ci named #{ci_service}"
+          exit(501)
         end
       end
       private :hardcover_coverage_data
@@ -40,9 +42,6 @@ module Slather
           f.write(hardcover_coverage_data)
           f.close
           `curl --form json_file=@#{f.path} #{hardcover_api_jobs_path}`
-        rescue StandardError => e
-          FileUtils.rm(f)
-          raise e
         end
         FileUtils.rm(f)
       end
@@ -55,7 +54,8 @@ module Slather
       def hardcover_base_url
         url = Project.yml["hardcover_base_url"]
         unless url
-          raise "No `hardcover_base_url` configured. Please add it to your `.slather.yml`"
+          STDERR.puts 'No `hardcover_base_url` configured. Please add it to your `.slather.yml`'
+          exit(502)
         end
         url
       end

--- a/lib/slather/version.rb
+++ b/lib/slather/version.rb
@@ -1,3 +1,3 @@
 module Slather
-  VERSION = '2.4.2' unless defined?(Slather::VERSION)
+  VERSION = '2.4.2-test' unless defined?(Slather::VERSION)
 end

--- a/spec/slather/coverage_service/coveralls_spec.rb
+++ b/spec/slather/coverage_service/coveralls_spec.rb
@@ -39,12 +39,13 @@ describe Slather::CoverageService::Coveralls do
 
       it "should raise an error if there is no TRAVIS_JOB_ID" do
         allow(fixtures_project).to receive(:travis_job_id).and_return(nil)
-        expect { fixtures_project.send(:coveralls_coverage_data) }.to raise_error(StandardError)
+        expect { fixtures_project.send(:coveralls_coverage_data) }.to exit_with_code(202)
       end
 
-      it "should raise an error if there is a COVERAGE_ACCESS_TOKEN" do        
+      it "should raise an error if there is a COVERAGE_ACCESS_TOKEN" do
+        allow(fixtures_project).to receive(:travis_job_id).and_return("9182")
         allow(fixtures_project).to receive(:coverage_access_token).and_return("abc123")
-        expect { fixtures_project.send(:coveralls_coverage_data) }.to raise_error(StandardError)
+        expect { fixtures_project.send(:coveralls_coverage_data) }.to exit_with_code(200)
       end
 
     end
@@ -61,12 +62,13 @@ describe Slather::CoverageService::Coveralls do
 
       it "should raise an error if there is no TRAVIS_JOB_ID" do
         allow(fixtures_project).to receive(:travis_job_id).and_return(nil)
-        expect { fixtures_project.send(:coveralls_coverage_data) }.to raise_error(StandardError)
+        expect { fixtures_project.send(:coveralls_coverage_data) }.to exit_with_code(202)
       end
 
-      it "should raise an error if there is no COVERAGE_ACCESS_TOKEN" do        
+      it "should raise an error if there is no COVERAGE_ACCESS_TOKEN" do
+        allow(fixtures_project).to receive(:travis_job_id).and_return("9182")
         allow(fixtures_project).to receive(:coverage_access_token).and_return("")
-        expect { fixtures_project.send(:coveralls_coverage_data) }.to raise_error(StandardError)
+        expect { fixtures_project.send(:coveralls_coverage_data) }.to exit_with_code(201)
       end
 
     end
@@ -86,7 +88,7 @@ describe Slather::CoverageService::Coveralls do
 
       it "should raise an error if there is no CIRCLE_BUILD_NUM" do
         allow(fixtures_project).to receive(:circleci_job_id).and_return(nil)
-        expect { fixtures_project.send(:coveralls_coverage_data) }.to raise_error(StandardError)
+        expect { fixtures_project.send(:coveralls_coverage_data) }.to exit_with_code(203)
       end
     end
 
@@ -104,13 +106,13 @@ describe Slather::CoverageService::Coveralls do
 
       it "should raise an error if there is no BUILD_ID" do
         allow(fixtures_project).to receive(:jenkins_job_id).and_return(nil)
-        expect { fixtures_project.send(:coveralls_coverage_data) }.to raise_error(StandardError)
+        expect { fixtures_project.send(:coveralls_coverage_data) }.to exit_with_code(204)
       end
     end
 
     it "should raise an error if it does not recognize the ci_service" do
       fixtures_project.ci_service = :jenkins_ci
-      expect { fixtures_project.send(:coveralls_coverage_data) }.to raise_error(StandardError)
+      expect { fixtures_project.send(:coveralls_coverage_data) }.to exit_with_code(207)
     end
 
     context "coverage_service is :teamcity" do
@@ -127,7 +129,7 @@ describe Slather::CoverageService::Coveralls do
 
       it "should raise an error if there is no TC_BUILD_NUMBER" do
         allow(fixtures_project).to receive(:teamcity_job_id).and_return(nil)
-        expect { fixtures_project.send(:coveralls_coverage_data) }.to raise_error(StandardError)
+        expect { fixtures_project.send(:coveralls_coverage_data) }.to exit_with_code(206)
       end
 
       it "should return the teamcity branch name" do
@@ -198,16 +200,13 @@ describe Slather::CoverageService::Coveralls do
         allow(fixtures_project).to receive(:travis_job_id).and_return("9182")
         allow(fixtures_project).to receive(:`).and_return("{\"message\":\"Couldn't find a repository matching this job.\",\"error\":true}")
         expect(fixtures_project).to receive(:`).once
-        expect { fixtures_project.post }.to raise_error(StandardError)        
+        expect { fixtures_project.post }.to exit_with_code(208)
       end
 
       it "should always remove the coveralls_json_file after it's done" do
         allow(fixtures_project).to receive(:`)
         allow(fixtures_project).to receive(:travis_job_id).and_return("9182")
         fixtures_project.post
-        expect(File.exist?("coveralls_json_file")).to be_falsy
-        allow(fixtures_project).to receive(:travis_job_id).and_return(nil)
-        expect { fixtures_project.post }.to raise_error(StandardError)
         expect(File.exist?("coveralls_json_file")).to be_falsy
       end
 

--- a/spec/slather/coverage_service/hardcover_spec.rb
+++ b/spec/slather/coverage_service/hardcover_spec.rb
@@ -51,13 +51,13 @@ describe Slather::CoverageService::Hardcover do
 
       it "should raise an error if there is no BUILD_NUMBER or JOB_NAME" do
         allow(fixtures_project).to receive(:jenkins_job_id).and_return(nil)
-        expect { fixtures_project.send(:hardcover_coverage_data) }.to raise_error(StandardError)
+        expect { fixtures_project.send(:hardcover_coverage_data) }.to exit_with_code(500)
       end
     end
 
     it "should raise an error if it does not recognize the ci_service" do
       fixtures_project.ci_service = :non_existing_ci
-      expect { fixtures_project.send(:hardcover_coverage_data) }.to raise_error(StandardError)
+      expect { fixtures_project.send(:hardcover_coverage_data) }.to exit_with_code(501)
     end
   end
 
@@ -109,9 +109,7 @@ describe Slather::CoverageService::Hardcover do
       allow(fixtures_project).to receive(:coverage_service_url).and_return("http://api.hardcover.io")
       fixtures_project.post
       expect(File.exist?("hardcover_json_file")).to be_falsy
-      allow(fixtures_project).to receive(:jenkins_job_id).and_return(nil)
-      expect { fixtures_project.post }.to raise_error(StandardError)
-      expect(File.exist?("hardcover_json_file")).to be_falsy
     end
+
   end
 end

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -60,7 +60,7 @@ describe Slather::Project do
 
     it "should raise an exception if no unignored project coverage file files were found" do
       fixtures_project.ignore_list = ["*fixturesTests*", "*fixtures*"]
-      expect {fixtures_project.coverage_files}.to raise_error(StandardError)
+      expect {fixtures_project.coverage_files}.to exit_with_code(102)
     end
   end
 
@@ -456,7 +456,7 @@ describe Slather::Project do
     end
 
     it "should raise an exception if it does not recognize the coverage service" do
-      expect { fixtures_project.coverage_service = "xcode bots, lol" }.to raise_error(StandardError)
+      expect { fixtures_project.coverage_service = "xcode bots, lol" }.to exit_with_code(109)
     end
   end
 
@@ -491,7 +491,7 @@ describe Slather::Project do
     end
 
     it "should fail for unknown coverage type" do
-      expect { fixtures_project_setup.slather_setup_for_coverage "this should fail" }.to raise_error(StandardError)
+      expect { fixtures_project_setup.slather_setup_for_coverage "this should fail" }.to exit_with_code(101)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,3 +60,28 @@ end
 JsonSpec.configure do
   exclude_keys "timestamp"
 end
+
+# From https://stackoverflow.com/questions/1480537/how-can-i-validate-exits-and-aborts-in-rspec
+# Syntax updates by dnedrow
+RSpec::Matchers.define :exit_with_code do |exp_code|
+  actual = nil
+  match do |block|
+    begin
+      block.call
+    rescue SystemExit => e
+      actual = e.status
+    end
+    actual and actual == exp_code
+  end
+  failure_message do |block|
+    "expected block to call exit(#{exp_code}) but exit" +
+        (actual.nil? ? " not called" : "(#{actual}) was called")
+  end
+  failure_message_when_negated do |block|
+    "expected block not to call exit(#{exp_code})"
+  end
+  description do
+    "expect block to call exit(#{exp_code})"
+  end
+  supports_block_expectations
+end


### PR DESCRIPTION
Converted raise StandardError usage to exit() with unique codes. Currently, the raise method only returns 0 or 1, which makes scripting difficult. With exit codes, scripts "driving" slather can react to specific exits. Also updated spec files where necessary and README.md.