### PR TITLE
Updated gemspec nokogiri def to limit to versions >=1.6 and <1.7 due …

### DIFF
--- a/slather.gemspec
+++ b/slather.gemspec
@@ -4,33 +4,33 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'slather/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "slather"
+  spec.name          = 'slather'
   spec.version       = Slather::VERSION
-  spec.authors       = ["Mark Larsen"]
-  spec.email         = ["mark@venmo.com"]
+  spec.authors       = ['Mark Larsen']
+  spec.email         = ['mark@venmo.com']
   spec.summary       = %q{Test coverage reports for Xcode projects}
-  spec.homepage      = "https://github.com/SlatherOrg/slather"
-  spec.license       = "MIT"
+  spec.homepage      = 'https://github.com/SlatherOrg/slather'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "coveralls"
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "rake", "~> 10.4"
-  spec.add_development_dependency "rspec", "~> 3.4"
-  spec.add_development_dependency "pry", "~> 0.9"
-  spec.add_development_dependency "cocoapods", "~> 1.2"
-  spec.add_development_dependency "json_spec", "~> 1.1.4"
-  spec.add_development_dependency "equivalent-xml", "~> 0.5.1"
+  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'rake', '~> 10.4'
+  spec.add_development_dependency 'rspec', '~> 3.4'
+  spec.add_development_dependency 'pry', '~> 0.9'
+  spec.add_development_dependency 'cocoapods', '~> 1.2'
+  spec.add_development_dependency 'json_spec', '~> 1.1.4'
+  spec.add_development_dependency 'equivalent-xml', '~> 0.5.1'
 
-  spec.add_dependency "clamp", "~> 0.6"
-  spec.add_dependency "xcodeproj", "~> 1.4"
-  spec.add_dependency "nokogiri", "~> 1.6"
-  spec.add_dependency "CFPropertyList", "~> 2.2"
+  spec.add_dependency 'clamp', '~> 0.6'
+  spec.add_dependency 'xcodeproj', '~> 1.4'
+  spec.add_dependency 'nokogiri', '>= 1.6', '< 1.7'
+  spec.add_dependency 'CFPropertyList', '~> 2.2'
 
   ## Version 5 needs Ruby 2.2, so we specify an upper bound to stay compatible with system ruby
   spec.add_runtime_dependency 'activesupport', '>= 4.0.2', '< 5'


### PR DESCRIPTION
…to default Ruby versions in El Capitan/Sierra.

Also replaced double quotes around non-interpolated values with single quote to clear lint warnings.