### PR TITLE
Add --profdata-file option.

### DIFF
--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -31,6 +31,7 @@ class CoverageCommand < Clamp::Command
   option ["--binary-basename"], "BINARY_BASENAME", "Basename of the file against which the coverage will be run", :multivalued => true
   option ["--source-files"], "SOURCE_FILES", "A Dir.glob compatible pattern used to limit the lookup to specific source files. Ignored in gcov mode.", :multivalued => true
   option ["--decimals"], "DECIMALS", "The amount of decimals to use for % coverage reporting"
+  option ["--profdata-file"], "PROFDATA_FILE", "The full path to the .profdata file. Optional - defaults to searching in the build directory if not specified."
 
   def execute
     puts "Slathering..."
@@ -50,6 +51,7 @@ class CoverageCommand < Clamp::Command
     setup_binary_basename
     setup_source_files
     setup_decimals
+    setup_profdata_file
 
     project.configure
 
@@ -156,5 +158,9 @@ class CoverageCommand < Clamp::Command
 
   def setup_decimals
     project.decimals = decimals if decimals
+  end
+
+  def setup_profdata_file
+    project.custom_profdata_file_path = profdata_file if profdata_file
   end
 end

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -45,7 +45,7 @@ module Slather
 
     attr_accessor :build_directory, :ignore_list, :ci_service, :coverage_service, :coverage_access_token, :source_directory,
       :output_directory, :xcodeproj, :show_html, :verbose_mode, :input_format, :scheme, :workspace, :binary_file, :binary_basename, :source_files,
-      :decimals, :llvm_version, :configuration
+      :decimals, :llvm_version, :configuration, :custom_profdata_file_path
 
     alias_method :setup_for_coverage, :slather_setup_for_coverage
 
@@ -173,6 +173,11 @@ module Slather
     end
 
     def profdata_file
+      if custom_profdata_file_path
+        return custom_profdata_file_path if File.exist?(custom_profdata_file_path)
+        raise StandardError, "Profdata file not found at --profdata-file path '#{custom_profdata_file_path}'."
+      end
+
       profdata_coverage_dir = self.profdata_coverage_dir
       if profdata_coverage_dir == nil
         raise StandardError, "No coverage directory found. Please make sure the \"Code Coverage\" checkbox is enabled in your scheme's Test action or the build_directory property is set."


### PR DESCRIPTION
When using [bluepill](https://github.com/linkedin/bluepill) coverage data is output into a different directory than the build directory, and has to be merged into a `.profdata` file using `xcrun llvm-profdata merge`. Instead of moving the Coverage.profdata into the build directory, I added this option.