### PR TITLE
Xcode 9 support without extra puts

### DIFF
--- a/lib/slather/coverage_service/simple_output.rb
+++ b/lib/slather/coverage_service/simple_output.rb
@@ -43,6 +43,7 @@ module Slather
         end
 
         total_percentage = decimal_f([(total_project_lines_tested / total_project_lines.to_f) * 100.0])
+        puts "Tested #{total_project_lines_tested}/#{total_project_lines} statements"
         puts "Test Coverage: #{total_percentage}%"
       end
 

--- a/lib/slather/coverage_service/simple_output.rb
+++ b/lib/slather/coverage_service/simple_output.rb
@@ -43,7 +43,6 @@ module Slather
         end
 
         total_percentage = decimal_f([(total_project_lines_tested / total_project_lines.to_f) * 100.0])
-        puts "Tested #{total_project_lines_tested}/#{total_project_lines} statements"
         puts "Test Coverage: #{total_percentage}%"
       end
 

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -167,10 +167,10 @@ module Slather
         # Xcode 7.3 moved the location of Coverage.profdata
         dir = Dir[File.join("#{build_directory}","/**/CodeCoverage")].first
       end
-      
+
       if dir == nil
         # Xcode 9 moved the location of Coverage.profdata
-        dir = Dir[File.join("#{build_directory}","/**/ProfileData")].first
+        dir = Dir.glob(File.join("#{build_directory}","/**/ProfileData/*")).first
       end
 
       raise StandardError, "No coverage directory found." unless dir != nil

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -155,7 +155,6 @@ module Slather
     end
 
     def profdata_coverage_dir
-      print build_directory
       raise StandardError, "The specified build directory (#{self.build_directory}) does not exist" unless File.exists?(self.build_directory)
       dir = nil
       if self.scheme

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -170,7 +170,7 @@ module Slather
       
       if dir == nil
         # Xcode 9 moved the location of Coverage.profdata
-        dir = Dir[File.join("#{build_directory}","/**/ProfileData")].glob("**/").first
+        dir = Dir[File.join("#{build_directory}","/**/ProfileData")].first
       end
 
       raise StandardError, "No coverage directory found." unless dir != nil

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -155,6 +155,7 @@ module Slather
     end
 
     def profdata_coverage_dir
+      print build_directory
       raise StandardError, "The specified build directory (#{self.build_directory}) does not exist" unless File.exists?(self.build_directory)
       dir = nil
       if self.scheme

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -171,7 +171,7 @@ module Slather
 
       if dir == nil
         # Xcode 9 moved the location of Coverage.profdata
-        dir = Dir.glob(File.join("#{build_directory}","../**/ProfileData/*")).first
+        dir = Dir[File.expand_path("..", "#{build_directory}")].first
       end
 
       raise StandardError, "No coverage directory found." unless dir != nil

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -171,7 +171,7 @@ module Slather
 
       if dir == nil
         # Xcode 9 moved the location of Coverage.profdata
-        dir = Dir.glob(File.join("#{build_directory}","/**/ProfileData/*")).first
+        dir = Dir.glob(File.join("#{build_directory}","../**/ProfileData/*")).first
       end
 
       raise StandardError, "No coverage directory found." unless dir != nil

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -170,7 +170,7 @@ module Slather
       
       if dir == nil
         # Xcode 9 moved the location of Coverage.profdata
-        dir = Dir[File.join("#{build_directory}","/**/ProfileData")].first.glob("**/").first
+        dir = Dir[File.join("#{build_directory}","/**/ProfileData")].glob("**/").first
       end
 
       raise StandardError, "No coverage directory found." unless dir != nil

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -167,6 +167,11 @@ module Slather
         # Xcode 7.3 moved the location of Coverage.profdata
         dir = Dir[File.join("#{build_directory}","/**/CodeCoverage")].first
       end
+      
+      if dir == nil
+        # Xcode 9 moved the location of Coverage.profdata
+        dir = Dir[File.join("#{build_directory}","/**/ProfileData")].first.glob("**/").first
+      end
 
       raise StandardError, "No coverage directory found." unless dir != nil
       dir


### PR DESCRIPTION
Some time ago @ivanbruel opened #321 to support Xcode 9. In the last commit, he added an extra `puts` that interferes with the tests.

I am removing the `puts` hoping a new Slather release can be made soon. 