### PR TITLE
Xcode 9 support

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -170,7 +170,17 @@ module Slather
 
       if dir == nil && Slather.xcode_version[0] >= 9
         # Xcode 9 moved the location of Coverage.profdata
-        dir = Pathname.new(Dir[File.join(build_directory, "/**/ProfileData/*/Coverage.profdata")].first).parent()
+        coverage_files = Dir[File.join(build_directory, "/**/ProfileData/*/Coverage.profdata")]
+
+        if coverage_files.count == 0
+          # Look up one directory
+          # The ProfileData directory is next to Intermediates.noindex (in previous versions of Xcode the coverage was inside Intermediates)
+          coverage_files = Dir[File.join(build_directory, "../**/ProfileData/*/Coverage.profdata")]
+        end
+
+        if coverage_files != nil
+          dir = Pathname.new(coverage_files.first).parent()
+        end
       end
 
       raise StandardError, "No coverage directory found." unless dir != nil

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -414,6 +414,7 @@ module Slather
         search_dir = profdata_coverage_dir
 
         if Slather.xcode_version[0] >= 9
+          # Go from the directory containing Coverage.profdata back to the directory containing Products (back out of ProfileData/UUID-dir)
           search_dir = File.join(search_dir, '../..')
         end
 

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -158,14 +158,15 @@ module Slather
       raise StandardError, "The specified build directory (#{self.build_directory}) does not exist" unless File.exists?(self.build_directory)
       dir = nil
       if self.scheme
-        dir = Dir[File.join("#{build_directory}","/**/CodeCoverage/#{self.scheme}")].first
+        dir = Dir[File.join(build_directory,"/**/CodeCoverage/#{self.scheme}")].first
       else
-        dir = Dir[File.join("#{build_directory}","/**/#{first_product_name}")].first
+        dir = Dir[File.join(build_directory,"/**/#{first_product_name}")].first
       end
 
       if dir == nil
         # Xcode 7.3 moved the location of Coverage.profdata
-        dir = Dir[File.join("#{build_directory}","/**/CodeCoverage")].first
+        dir = Dir[File.join(build_directory,"/**/CodeCoverage")].first
+      end
 
       if dir == nil && Slather.xcode_version[0] >= 9
         # Xcode 9 moved the location of Coverage.profdata

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -166,6 +166,10 @@ module Slather
       if dir == nil
         # Xcode 7.3 moved the location of Coverage.profdata
         dir = Dir[File.join("#{build_directory}","/**/CodeCoverage")].first
+
+      if dir == nil && Slather.xcode_version[0] >= 9
+        # Xcode 9 moved the location of Coverage.profdata
+        dir = Pathname.new(Dir[File.join(build_directory, "/**/ProfileData/*/Coverage.profdata")].first).parent()
       end
 
       raise StandardError, "No coverage directory found." unless dir != nil
@@ -406,9 +410,14 @@ module Slather
         end
 
         search_list = binary_basename || find_buildable_names(xcscheme)
+        search_dir = profdata_coverage_dir
+
+        if Slather.xcode_version[0] >= 9
+          search_dir = File.join(search_dir, '../..')
+        end
 
         search_list.each do |search_for|
-          found_product = Dir["#{profdata_coverage_dir}/Products/#{configuration}*/#{search_for}*"].sort { |x, y|
+          found_product = Dir["#{search_dir}/Products/#{configuration}*/#{search_for}*"].sort { |x, y|
             # Sort the matches without the file extension to ensure better matches when there are multiple candidates
             # For example, if the binary_basename is Test then we want Test.app to be matched before Test Helper.app
             File.basename(x, File.extname(x)) <=> File.basename(y, File.extname(y))


### PR DESCRIPTION
Additional Xcode 9 support (thank you to #321 and #338).
Most of the tests pass when run against Xcode 9, but 4 tests still fail due to expecting Xcode 8's directory layout. These tests can be updated once Travis is switched over to Xcode 9.