### PR TITLE
exclude swiftmodule from Product search

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -435,6 +435,7 @@ module Slather
             File.basename(x, File.extname(x)) <=> File.basename(y, File.extname(y))
           }.reject { |path|
             path.end_with? ".dSYM"
+            path.end_with? ".swiftmodule"
           }.first
 
           if found_product and File.directory? found_product


### PR DESCRIPTION
Sometimes, Slather returns "No product binary found" while there's one in the build dir... 
After a debug session it appears that the "first" found_product is the .swiftmodule and not the .app.
Excluding it like the .dSYM get it working again !

Closes #347 