### PR TITLE
adding pass through architecture argument

### DIFF
--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -32,6 +32,7 @@ class CoverageCommand < Clamp::Command
   option ["--binary-basename"], "BINARY_BASENAME", "Basename of the file against which the coverage will be run", :multivalued => true
   option ["--source-files"], "SOURCE_FILES", "A Dir.glob compatible pattern used to limit the lookup to specific source files. Ignored in gcov mode.", :multivalued => true
   option ["--decimals"], "DECIMALS", "The amount of decimals to use for % coverage reporting"
+  option ["--arch"], "ARCH", "Passthrough architecture to llvm-cov. This is useful when project settings are set to build all architectures"
 
   def execute
     puts "Slathering..."
@@ -51,6 +52,7 @@ class CoverageCommand < Clamp::Command
     setup_binary_basename
     setup_source_files
     setup_decimals
+    setup_architecture
 
     project.configure
 
@@ -160,4 +162,9 @@ class CoverageCommand < Clamp::Command
   def setup_decimals
     project.decimals = decimals if decimals
   end
+
+  def setup_architecture
+    project.architecture = arch if arch
+  end
+
 end

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -45,7 +45,7 @@ module Slather
 
     attr_accessor :build_directory, :ignore_list, :ci_service, :coverage_service, :coverage_access_token, :source_directory,
       :output_directory, :xcodeproj, :show_html, :verbose_mode, :input_format, :scheme, :workspace, :binary_file, :binary_basename, :source_files,
-      :decimals, :llvm_version, :configuration
+      :decimals, :llvm_version, :configuration, :architecture
 
     alias_method :setup_for_coverage, :slather_setup_for_coverage
 
@@ -211,7 +211,12 @@ module Slather
         raise StandardError, "No binary file found."
       end
 
-      llvm_cov_args = %W(show -instr-profile #{profdata_file_arg} #{binary_path})
+      if self.architecture
+        llvm_cov_args = %W(show -instr-profile #{profdata_file_arg} #{binary_path} --arch #{self.architecture})
+      else
+        llvm_cov_args = %W(show -instr-profile #{profdata_file_arg} #{binary_path})
+      end
+
       `xcrun llvm-cov #{llvm_cov_args.shelljoin} #{source_files.shelljoin}`
     end
     private :unsafe_profdata_llvm_cov_output


### PR DESCRIPTION
This solves the issue of 'Failed to load coverage: Unknown architecture named:'. One prescribed solution was to change the Xcode project settings for debug builds to only build the active architecture. This is not currently an option for our project. llvm-cov allows for an architecture to be specified, so this change allows a user to optionally specify the architecture to pass through to llvm-cov.