### PR TITLE
Support for specifying a specific binary architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 script: bundle exec rake
-osx_image: xcode8.3
+osx_image: xcode9.2
 
 before_install:
   - curl http://curl.haxx.se/ca/cacert.pem -o /usr/local/share/cacert.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Added absolute statement count to simple output (instead of showing just a percentage)
+  [barrault01](https://github.com/barrault01), [ivanbrunel](https://github.com/ivanbruel)
+  [#365](https://github.com/SlatherOrg/slather/pull/365)
+
 * Updated nokogiri dependency version
   [#363](https://github.com/SlatherOrg/slather/issues/363), [#366](https://github.com/SlatherOrg/slather/pull/366)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Support for specifying a specific binary architecture
+  [ksuther](https://github.com/ksuther), [nickolas-pohilets](https://github.com/nickolas-pohilets)
+  [#367](https://github.com/SlatherOrg/slather/pull/367)
+
 * Added absolute statement count to simple output (instead of showing just a percentage)
   [barrault01](https://github.com/barrault01), [ivanbrunel](https://github.com/ivanbruel)
   [#365](https://github.com/SlatherOrg/slather/pull/365)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ If you use a different configuration for your tests:
 $ slather coverage -s --scheme YourXcodeSchemeName --configuration YourBuildConfigurationName path/to/project.xcodeproj
 ```
 
+If your configuration produces a universal binary you need to specify a specific architecture to use: 
+
+```sh
+$ slather coverage -s --arch x86_64 --scheme YourXcodeSchemeName --configuration YourBuildConfigurationName path/to/project.xcodeproj
+```
+
 ### Setup for Xcode 5 and 6
 
 Run this command to enable the `Generate Test Coverage` and `Instrument Program Flow` flags for your project:

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -30,6 +30,7 @@ class CoverageCommand < Clamp::Command
   option ["--workspace"], "WORKSPACE", "The workspace that the project was built in"
   option ["--binary-file"], "BINARY_FILE", "The binary file against the which the coverage will be run", :multivalued => true
   option ["--binary-basename"], "BINARY_BASENAME", "Basename of the file against which the coverage will be run", :multivalued => true
+  option ["--arch"], "ARCH", "Architecture to use from universal binaries"
   option ["--source-files"], "SOURCE_FILES", "A Dir.glob compatible pattern used to limit the lookup to specific source files. Ignored in gcov mode.", :multivalued => true
   option ["--decimals"], "DECIMALS", "The amount of decimals to use for % coverage reporting"
 
@@ -49,6 +50,7 @@ class CoverageCommand < Clamp::Command
     setup_workspace
     setup_binary_file
     setup_binary_basename
+    setup_arch
     setup_source_files
     setup_decimals
 
@@ -151,6 +153,10 @@ class CoverageCommand < Clamp::Command
 
   def setup_binary_basename
     project.binary_basename = binary_basename_list if !binary_basename_list.empty?
+  end
+
+  def setup_arch
+    project.arch = arch
   end
 
   def setup_source_files

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -509,9 +509,9 @@ describe Slather::Project do
     it "should print out environment info when in verbose_mode" do
       project_root = Pathname("./").realpath
 
-      ["\nProcessing coverage file: #{project_root}/spec/DerivedData/libfixtures/Build/Intermediates/CodeCoverage/Coverage.profdata",
+      [/\nProcessing coverage file: #{project_root}\/spec\/DerivedData\/libfixtures\/Build\/ProfileData\/[A-Z0-9-]+\/Coverage.profdata/,
        "Against binary files:",
-       "\t#{project_root}/spec/DerivedData/libfixtures/Build/Intermediates/CodeCoverage/Products/Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests",
+       "\t#{project_root}/spec/DerivedData/libfixtures/Build/Products/Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests",
        "\n"
       ].each do |line|
         expect(fixtures_project).to receive(:puts).with(line)
@@ -525,7 +525,7 @@ describe Slather::Project do
 
       project_root = Pathname("./").realpath
 
-      ["\nProcessing coverage file: #{project_root}/spec/DerivedData/libfixtures/Build/Intermediates/CodeCoverage/Coverage.profdata",
+      [/\nProcessing coverage file: #{project_root}\/spec\/DerivedData\/libfixtures\/Build\/ProfileData\/[A-Z0-9-]+\/Coverage.profdata/,
        "No binary files found.",
        "\n",
       ].each do |line|
@@ -588,7 +588,7 @@ describe Slather::Project do
     let(:configuration) { 'Debug' }
     let(:project_root) { Pathname("./").realpath }
     let(:coverage_dir) { "#{project_root}/spec/DerivedData/DerivedData/Build/Intermediates/CodeCoverage" }
-    let(:search_dir) { "#{coverage_dir}/Products/#{configuration}*/fixtures*" }
+    let(:search_dir) { "#{coverage_dir}/../../Products/#{configuration}*/fixtures*" }
     let(:binary_file) { "#{coverage_dir}/Products/#{configuration}-iphonesimulator/fixtures.app/fixtures" }
 
     before do

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -163,10 +163,17 @@ describe Slather::Project do
 
     it "should find the product path for a scheme with no buildable products" do
       allow(fixtures_project).to receive(:scheme).and_return("fixturesTests")
+      allow(fixtures_project).to receive(:arch).and_return("x86_64")
       fixtures_project.send(:configure_binary_file)
       binary_file_location = fixtures_project.send(:binary_file)
       expect(binary_file_location.count).to eq(1)
       expect(binary_file_location.first).to end_with("Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests")
+    end
+
+    it "should not find a product path for an invalid architecture" do
+      allow(fixtures_project).to receive(:scheme).and_return("fixturesTests")
+      allow(fixtures_project).to receive(:arch).and_return("arm64")
+      expect { fixtures_project.send(:configure_binary_file) }.to raise_error.with_message(/No product binary found in (.+)./)
     end
 
     it "should find multiple unique paths for a scheme with serveral buildable/testable products" do


### PR DESCRIPTION
Based on #346 (and #362).

There's now an `arch` argument or config option to specify what architecture the binary is in. This argument is used by `find_binary_files` and passed to `llvm-cov` so universal binaries use the right architecture.

I believe this will fix #353 as well.