### PR TITLE
Fix single source file in binary predicate

### DIFF
--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -27,7 +27,7 @@ module Slather
 
     def path_on_first_line?
       path = self.source.split("\n")[0].sub ":", ""
-      !path.include?("|//")
+      !path.lstrip.start_with?("1|")
     end
 
     def source_file_pathname


### PR DESCRIPTION
Fixing #376 issue.

`“    1|      <NUMBER>|<CODE>”` line (corresponds to Xcode 9.3 `xcrun llvm-cov show` output) should be detected as `!path_on_first_line?`. Previous `path_on_first_line?` implementation returns `true` for that example failing to process single source binary.
