### PR TITLE
Don't generate line 0 in profdata_coverage_file.rb from line with error

### DIFF
--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -65,13 +65,16 @@ module Slather
 
     def source_code_lines
       lines = self.source.split("\n")[(path_on_first_line? ? 1 : 0)..-1]
-      lines.select do |line|
-        # Ignore crash / error lines in format like
-        #   ------------------
-        #   | Unexecuted instantiation: _Something
-        #   ------------------
-        !(/^\s*(\|\s|--).*/ === line)
+      if self.line_numbers_first
+        lines = lines.select do |line|
+          # Ignore crash / error lines in format like
+          #   ------------------
+          #   | Unexecuted instantiation: _Something
+          #   ------------------
+          !(line.lstrip.start_with?("|") || line.lstrip.start_with?("--"))
+        end
       end
+      lines
     end
 
     def source_data

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -64,7 +64,14 @@ module Slather
     end
 
     def source_code_lines
-      self.source.split("\n")[(path_on_first_line? ? 1 : 0)..-1]
+      lines = self.source.split("\n")[(path_on_first_line? ? 1 : 0)..-1]
+      lines.select do |line|
+        # Ignore crash / error lines in format like
+        #   ------------------
+        #   | Unexecuted instantiation: _Something
+        #   ------------------
+        !(/^\s*(\|\s|--).*/ === line)
+      end
     end
 
     def source_data


### PR DESCRIPTION
I was able to reproduce issue #290 by having error in coverage processed using `profdata_coverage_file.rb`

### Problem description
When passing Cobertura XML format generated using `slather` to `sonar-scanner`, it crashes on error like this:
```
java.lang.IllegalStateException: Measure with line 0 for file '/somepath/sonar-scanner/SomeClass.swift' must be > 0
```
It makes sense since there is no "line 0" in source code (text file).

In my case there was line number 0 generated in Cobertura XML output like this:
```
<class name="SomeClass" filename="SomeModule/SomeClass.swift" line-rate="0.9746835443037974" branch-rate="1.0000000000000000" complexity="0.0">
    <methods/>
    <lines>
        <line number="30" branch="false" hits="16200"/>
        <line number="0" branch="false" hits="30"/>
```

I found it is because the source being passed to `ProfdataCoverageFile` contains error in following format:
```
...
30|  16.2k|    private let someVar: [String] = SomeClass.sharedInstance.someProperty.compactMap { $0[0] }
------------------
| _T010SomeModule9SomeClassC7someVar33_B9BF662D291A982BAD48D03250F9A280LLSaySSGvpfiSSSgSScfU_:
|   30|  16.2k|    private let someVar: [String] = SomeClass.sharedInstance.someProperty.compactMap { $0[0] }
------------------
| Unexecuted instantiation: _T010SomeModule9SomeClassCACycfC
------------------
| Unexecuted instantiation: _T010SomeModule9SomeClassCACSgSo7NSCoderC5coder_tcfC
------------------
31|       |
32|       |    /**
...
```

### Implementation
This change just filters out these lines from `source_code_lines` and it fixes the issue in my case.

It is implemented only in case of `self.line_numbers_first` because this case is easy and fast to detect and handle.
Detecting the issue if `self.line_numbers_first == false` would require rather complex regex due to duplication of valid source line in the error listing.

### Solution
This change prevents the `0` line from appearing in XML coverage report.

### Tests
Not having good enough knowledge of `slather` and `ruby`, I didn't find simple / elegant solution to adjust tests for this case (tests are using `line_numbers_first = false`, while my fix is for `true` case).
Sorry about that.

### Notes
I will appreciate any suggestion or better solution for this problem.
However I would appreciate some fix for this problem to be released in `slather` so I don't have to use fork or some XML text manipulation in production to workaround this problem.

Thanks to everyone for your time to review!