### PR TITLE
Fix: undefined method `split' for nil:NilClass (NoMethodError)

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -535,7 +535,7 @@ module Slather
     def matches_arch(binary_path)
       if self.arch
         lipo_output = `lipo -info "#{binary_path}"`
-        archs_in_binary = lipo_output.split(':').last.split(' ')
+        archs_in_binary = lipo_output.split(':').last.to_s.split(' ')
         archs_in_binary.include? self.arch
       else
         true


### PR DESCRIPTION
Issue:
/Library/Ruby/Gems/2.3.0/gems/slather-2.4.5/lib/slather/project.rb:537:in `matches_arch': undefined method `split' for nil:NilClass (NoMethodError)

Apparently issue still exists and I was thinking let's submit the fix for it.

Fix: casting/converting lipo_output to string before using 2nd split did the trick for me 
