### PR TITLE
Chunk pathnames_per_binary into segments that do not exceed the OS ARG_MAX size for calls to llvm-cov

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -149,12 +149,12 @@ module Slather
       if pathnames_per_binary.join.size * 1.1  < self.class.max_os_argument_size
         coverage_files.concat(create_coverage_files(binary_path, pathnames_per_binary))
       elsif pathnames_per_binary.count >=2
-        # If it's too big pathnames_per_binary is split in two halfs which are then processed independently
+        # If pathnames_per_binary is too big it's split in two halfs which are then processed independently
         left,right = pathnames_per_binary.each_slice( (pathnames_per_binary.size/2.0).round ).to_a
-        coverage_files.concat(create_coverage_files_for_binary(binary_path, left)) if left.size > 0
-        coverage_files.concat(create_coverage_files_for_binary(binary_path, right)) if right.size > 0
+        coverage_files.concat(create_coverage_files_for_binary(binary_path, left))
+        coverage_files.concat(create_coverage_files_for_binary(binary_path, right))
       else 
-        raise StandardError, "The work can't be sliced into multiple chunks"
+        raise StandardError, "Errno::E2BIG: Argument list too long. A path in your project is close to the E2BIG limit. https://github.com/SlatherOrg/slather/pull/414"
       end
 
       coverage_files

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -148,11 +148,13 @@ module Slather
       # The size is padded with 10% to account for added spaces etc. in the final argument
       if pathnames_per_binary.join.size * 1.1  < self.class.max_os_argument_size
         coverage_files.concat(create_coverage_files(binary_path, pathnames_per_binary))
-      else
+      elsif pathnames_per_binary.count >=2
         # If it's too big pathnames_per_binary is split in two halfs which are then processed independently
         left,right = pathnames_per_binary.each_slice( (pathnames_per_binary.size/2.0).round ).to_a
         coverage_files.concat(create_coverage_files_for_binary(binary_path, left)) if left.size > 0
         coverage_files.concat(create_coverage_files_for_binary(binary_path, right)) if right.size > 0
+      else 
+        raise StandardError, "The work can't be sliced into multiple chunks"
       end
 
       coverage_files

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -143,19 +143,15 @@ module Slather
 
     def create_coverage_files_for_binary(binary_path, pathnames_per_binary)
       coverage_files = []
-      # Chunk pathnames_per_binary into segments that do not exceed the OS ARG_MAX size
-      # There is an overhead to the total_size due to spaces and such so we add 20%
-      total_size = pathnames_per_binary.join.size 
-      number_of_chunks = [(total_size.to_f / 200.0).ceil, 1].max
-      # find out how many items there should be in each chunk
-      chunk_size = [(pathnames_per_binary.count.to_f / number_of_chunks).ceil, 1].max
-      pathnames_per_binary.each_slice(chunk_size).to_a.each do |pathnames|
-        slice_size = pathnames.join.size 
-        if slice_size < 200.0 
-          coverage_files.concat(create_coverage_files(binary_path, pathnames))
-        else
-          coverage_files.concat(create_coverage_files_for_binary(binary_path, pathnames))
-        end
+
+      # Chunk pathnames_per_binary into segments that do not exceed the OS ARG_MAX size for calls to llvm-cov
+      # The size is padded with 10% to account for added spaces atc in the final argument
+      if pathnames_per_binary.join.size * 1.1  < self.class.max_os_argument_size
+        coverage_files.concat(create_coverage_files(binary_path, pathnames_per_binary))
+      else
+        left,right = pathnames_per_binary.each_slice( (pathnames_per_binary.size/2.0).round ).to_a
+        coverage_files.concat(create_coverage_files_for_binary(binary_path, left))
+        coverage_files.concat(create_coverage_files_for_binary(binary_path, right))
       end
 
       coverage_files

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -141,7 +141,7 @@ describe Slather::Project do
 
     it "Should raise an error when the OS level argument size is too small to work with" do
       allow(fixtures_project.class).to receive(:max_os_argument_size).and_return(10)
-      expect { fixtures_project.send(:profdata_coverage_files) }.to raise_error(StandardError, "The work can't be sliced into multiple chunks")
+      expect { fixtures_project.send(:profdata_coverage_files) }.to raise_error(StandardError, "Errno::E2BIG: Argument list too long. A path in your project is close to the E2BIG limit. https://github.com/SlatherOrg/slather/pull/414")
     end
 
     it "Should return Coverage.profdata file objects when the OS level argument size is smaller than the input size" do

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -88,15 +88,11 @@ describe Slather::Project do
     end
   end
 
-  describe "#profdata_coverage_files" do
+  describe "#profdata_coverage_files with large file lists" do
     class SpecXcode7CoverageFile < Slather::ProfdataCoverageFile
     end
 
-    before(:each) do
-      allow(Dir).to receive(:[]).and_call_original
-      allow(Dir).to receive(:[]).with("#{fixtures_project.build_directory}/**/Coverage.profdata").and_return(["/some/path/Coverage.profdata"])
-      allow(fixtures_project).to receive(:binary_file).and_return(["Fixtures"])
-      allow(fixtures_project).to receive(:llvm_cov_export_output).and_return(%q(
+    llvm_cov_export_output = %q(
         {
            "data":[
               {
@@ -105,11 +101,18 @@ describe Slather::Project do
                        "filename":"spec/fixtures/fixtures/Fixtures.swift"
                     }
                  ]
+              },
+              {
+                 "files":[
+                    {
+                       "filename":"spec/fixtures/fixtures/Fixtures.swift"
+                    }
+                 ]
               }
            ]
-        }
-      ))
-      allow(fixtures_project).to receive(:profdata_llvm_cov_output).and_return("#{FIXTURES_SWIFT_FILE_PATH}:
+        })
+
+    profdata_llvm_cov_output = "#{FIXTURES_SWIFT_FILE_PATH}:
        |    0|
        |    1|import UIKit
        |    2|
@@ -124,19 +127,77 @@ describe Slather::Project do
        |   11|
       0|   12|    func applicationWillResignActive(application: UIApplication) {
       0|   13|    }
-      0|   14|}")
+      0|   14|}"
+
+    before(:each) do
+      allow(Dir).to receive(:[]).and_call_original
+      allow(Dir).to receive(:[]).with("#{fixtures_project.build_directory}/**/Coverage.profdata").and_return(["/some/path/Coverage.profdata"])
+      allow(fixtures_project).to receive(:binary_file).and_return(["Fixtures"])
+      allow(fixtures_project).to receive(:llvm_cov_export_output).and_return(llvm_cov_export_output)
+      allow(fixtures_project).to receive(:profdata_llvm_cov_output).and_return(profdata_llvm_cov_output)
+      allow(fixtures_project).to receive(:coverage_file_class).and_return(SpecXcode7CoverageFile)
+      allow(fixtures_project).to receive(:ignore_list).and_return([])
+    end
+
+    it "Should raise an error when the OS level argument size is too small to work with" do
+      allow(fixtures_project.class).to receive(:max_os_argument_size).and_return(10)
+      expect { fixtures_project.send(:profdata_coverage_files) }.to raise_error(StandardError, "The work can't be sliced into multiple chunks")
+    end
+
+    it "Should return Coverage.profdata file objects when the OS level argument size is smaller than the input size" do
+      allow(fixtures_project.class).to receive(:max_os_argument_size).and_return(llvm_cov_export_output.size/2)
+      allow(fixtures_project).to receive(:profdata_llvm_cov_output).and_return(profdata_llvm_cov_output << profdata_llvm_cov_output)
+      profdata_coverage_files = fixtures_project.send(:profdata_coverage_files)
+      profdata_coverage_files.each { |cf| expect(cf.kind_of?(SpecXcode7CoverageFile)).to be_truthy }
+      expect(profdata_coverage_files.map { |cf| cf.source_file_pathname.basename.to_s }).to eq(["Fixtures.swift"])
+    end
+  end
+
+  describe "#profdata_coverage_files" do
+    class SpecXcode7CoverageFile < Slather::ProfdataCoverageFile
+    end
+
+    llvm_cov_export_output = %q(
+        {
+           "data":[
+              {
+                 "files":[
+                    {
+                       "filename":"spec/fixtures/fixtures/Fixtures.swift"
+                    }
+                 ]
+              }
+           ]
+        })
+
+    profdata_llvm_cov_output = "#{FIXTURES_SWIFT_FILE_PATH}:
+       |    0|
+       |    1|import UIKit
+       |    2|
+       |    3|@UIApplicationMain
+       |    4|class AppDelegate: UIResponder, UIApplicationDelegate {
+       |    5|
+       |    6|    var window: UIWindow?
+       |    7|
+      1|    8|    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+      1|    9|        return true
+      1|   10|    }
+       |   11|
+      0|   12|    func applicationWillResignActive(application: UIApplication) {
+      0|   13|    }
+      0|   14|}"
+
+    before(:each) do
+      allow(Dir).to receive(:[]).and_call_original
+      allow(Dir).to receive(:[]).with("#{fixtures_project.build_directory}/**/Coverage.profdata").and_return(["/some/path/Coverage.profdata"])
+      allow(fixtures_project).to receive(:binary_file).and_return(["Fixtures"])
+      allow(fixtures_project).to receive(:llvm_cov_export_output).and_return(llvm_cov_export_output)
+      allow(fixtures_project).to receive(:profdata_llvm_cov_output).and_return(profdata_llvm_cov_output)
       allow(fixtures_project).to receive(:coverage_file_class).and_return(SpecXcode7CoverageFile)
       allow(fixtures_project).to receive(:ignore_list).and_return([])
     end
 
     it "should return Coverage.profdata file objects" do
-      profdata_coverage_files = fixtures_project.send(:profdata_coverage_files)
-      profdata_coverage_files.each { |cf| expect(cf.kind_of?(SpecXcode7CoverageFile)).to be_truthy }
-      expect(profdata_coverage_files.map { |cf| cf.source_file_pathname.basename.to_s }).to eq(["Fixtures.swift"])
-    end
-
-    it "should return Coverage.profdata file objects when get_arg_max returns a small value" do
-      allow(fixtures_project.class).to receive(:get_arg_max).and_return(200)
       profdata_coverage_files = fixtures_project.send(:profdata_coverage_files)
       profdata_coverage_files.each { |cf| expect(cf.kind_of?(SpecXcode7CoverageFile)).to be_truthy }
       expect(profdata_coverage_files.map { |cf| cf.source_file_pathname.basename.to_s }).to eq(["Fixtures.swift"])


### PR DESCRIPTION
I have encountered the issue in https://github.com/SlatherOrg/slather/issues/243 which is not easily solvable. This is an attempt to fix the problem by chunking calls llvm cov into smaller segments which are recombined. I'll give it some time to see if there are any problems.  