### PR TITLE
Fixed warnings re: dependency versions

### DIFF
--- a/slather.gemspec
+++ b/slather.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.17'
-  spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'coveralls', '~> 0'
+  spec.add_development_dependency 'simplecov', '~> 0'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.8'
   spec.add_development_dependency 'pry', '~> 0.12'
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'clamp', '~> 1.3'
   spec.add_dependency 'xcodeproj', '~> 1.7'
   spec.add_dependency 'nokogiri', '~> 1.8'
-  spec.add_dependency 'CFPropertyList', '>= 2.2'
+  spec.add_dependency 'CFPropertyList', '>= 2.2', '< 4'
 
   spec.add_runtime_dependency 'activesupport', '< 5', '>= 4.0.2'
 end


### PR DESCRIPTION
Fixed warnings re: dependency versions: coveralls, simplecov, CFPropertyList were open ended.