### PR TITLE
Fix `binary_basename` configuration key

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ slather coverage --binary-basename module1 --binary-basename module2 path/to/p
 ```
 You can also add it to the `.slather.yml` file as an array:
 ```yml
-binary-basename:
+binary_basename:
   - module1
   - module2
 ```


### PR DESCRIPTION
Hello, I was configuring my project with multiple targets and was expecting coverage data for all targets (using `.slather.yml`)

After a lot of debugging and reading source code I found that readme had a typo :)
https://github.com/SlatherOrg/slather/blob/25ebacbd1ddcb5494beee753af4046460f7e93d5/lib/slather/project.rb#L457-L459

