### PR TITLE
Fix `spec/slather/cocoapods_plugin_spec.rb` spec

### DIFF
--- a/spec/slather/cocoapods_plugin_spec.rb
+++ b/spec/slather/cocoapods_plugin_spec.rb
@@ -13,7 +13,7 @@ describe Slather do
       # Execute the post_install hook via CocoaPods
       sandbox_root = 'Pods'
       sandbox = Pod::Sandbox.new(sandbox_root)
-      context = Pod::Installer::PostInstallHooksContext.generate(sandbox, [])
+      context = Pod::Installer::PostInstallHooksContext.generate(sandbox, mock_project, [])
       Pod::HooksManager.run(:post_install, context, {'slather' => nil})
     end
   end


### PR DESCRIPTION
CocoaPods plugin got updated, and installed version (1.8.4) now accepts three arguments for generating

https://github.com/CocoaPods/CocoaPods/blob/21adb0c6664022428cbb742e5bd6abfa55f274e5/lib/cocoapods/installer/post_install_hooks_context.rb#L38-L62

This pull request fixes it by just passing mocked project file into generator method
