### PR TITLE
Update coveralls gem to match simplecov

### DIFF
--- a/slather.gemspec
+++ b/slather.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.17'
-  spec.add_development_dependency 'coveralls', '~> 0'
+  spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'simplecov', '~> 0'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.8'


### PR DESCRIPTION
Hello, I found that coveralls gem isn't properly set.

Thus it is failing to upload coverage data to coveralls.

This pull request adds explicit coveralls dependency version, so it can properly use simplecov gem and upload to coveralls 