### PR TITLE
Don't generate line 0 in profdata_coverage_file.rb from line with error

### DIFF
--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -64,7 +64,16 @@ module Slather
     end
 
     def source_code_lines
-      self.source.split("\n")[(path_on_first_line? ? 1 : 0)..-1]
+      lines = self.source.split("\n")[(path_on_first_line? ? 1 : 0)..-1]
+      ignore_error_lines(lines)
+    end
+
+    def ignore_error_lines(lines, line_numbers_first = self.line_numbers_first)
+      if line_numbers_first
+        lines.reject { |line| line.lstrip.start_with?('|', '--') }
+      else
+        lines
+      end
     end
 
     def source_data

--- a/spec/slather/profdata_coverage_spec.rb
+++ b/spec/slather/profdata_coverage_spec.rb
@@ -90,6 +90,23 @@ describe Slather::ProfdataCoverageFile do
     end
   end
 
+  describe '#ignore_error_lines' do
+    it 'should ignore lines starting with - when line_numbers_first is true' do
+      expect(profdata_coverage_file.ignore_error_lines(['--------'], true)).to eq([])
+      expect(profdata_coverage_file.ignore_error_lines(['--------', 'not ignored'], true)).to eq(['not ignored'])
+    end
+
+    it 'should ignore lines starting with | when line_numbers_first is true' do
+      expect(profdata_coverage_file.ignore_error_lines(['| Unexecuted instantiation'], true)).to eq([])
+      expect(profdata_coverage_file.ignore_error_lines(['| Unexecuted instantiation', 'not ignored'], true)).to eq(['not ignored'])
+    end
+
+    it 'should not ignore any lines when line_numbers_first is false' do
+      lines = ['| Unexecuted instantiation', '------']
+      expect(profdata_coverage_file.ignore_error_lines(lines, false)).to eq(lines)
+    end
+  end
+
   describe "#coverage_for_line" do
     it "should return the number of hits for the line" do
       expect(profdata_coverage_file.coverage_for_line("      10|   40|    func applicationWillTerminate(application: UIApplication) {", false)).to eq(10)
@@ -115,6 +132,10 @@ describe Slather::ProfdataCoverageFile do
       expect(profdata_coverage_file.coverage_for_line("   18|      1|    return a + b;", true)).to eq(1)
       expect(profdata_coverage_file.coverage_for_line("   18|  11.8k|    return a + b;", true)).to eq(11800)
       expect(profdata_coverage_file.coverage_for_line("   18|  2.58M|    return a + b;", true)).to eq(2580000)
+    end
+
+    it 'should ignore errors in profdata' do
+      expect(profdata_coverage_file.coverage_for_line('------------------', true)).to eq(nil)
     end
   end
 


### PR DESCRIPTION
There is already a PR open since May 2018 for this problem: https://github.com/SlatherOrg/slather/pull/387

The issue is still valid when passing the XML to `sonar-scanner`.

I changed a few minor things compared to the original PR and I also included some test cases. I had troubles running all tests locally, hopefully this meets the coverage expectations.