### PR TITLE
Remove activesupport constraints

### DIFF
--- a/lib/slather/version.rb
+++ b/lib/slather/version.rb
@@ -1,3 +1,3 @@
 module Slather
-  VERSION = '2.4.9' unless defined?(Slather::VERSION)
+  VERSION = '2.5.0-beta.1' unless defined?(Slather::VERSION)
 end

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.8'
   spec.add_development_dependency 'pry', '~> 0.12'
-  spec.add_development_dependency 'cocoapods', '~> 1.5'
+  spec.add_development_dependency 'cocoapods', '~> 1.10.beta.1'
   spec.add_development_dependency 'json_spec', '~> 1.1'
   spec.add_development_dependency 'equivalent-xml', '~> 0.6'
 
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri', '~> 1.8'
   spec.add_dependency 'CFPropertyList', '>= 2.2', '< 4'
 
-  spec.add_runtime_dependency 'activesupport', '< 5', '>= 4.0.2'
+  spec.add_runtime_dependency 'activesupport'
 end


### PR DESCRIPTION
These seem to have come from our downstream dependency, cocoapods, and
they have dropped the activesupport constraint in order to inherit it
from the core project.

Issue number: #465 