### PR TITLE
Implementing Github Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ ignore:
   - ProjectTestsGroup/*
 ```
 
-And then in your `.travis.yml` or `circle.yml`, call `slather` after a successful build:
+And then in your `.travis.yml` or `circle.yml` or `github-action.yml`, call `slather` after a successful build:
 
 ```yml
 # .travis.yml
@@ -165,6 +165,22 @@ after_success: slather
 test:
   post:
     - bundle exec slather
+
+```
+
+```yml
+# github-action.yml
+  myjob:
+    steps:
+      - run: |
+          bundle config path vendor/bundle
+          bundle install --without=documentation --jobs 4 --retry 3
+
+      - run: bundle exec slather
+        env:
+          GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
+          CI_PULL_REQUEST: ${{ github.event.number }}
+          COVERAGE_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -175,10 +175,13 @@ test:
       - run: |
           bundle config path vendor/bundle
           bundle install --without=documentation --jobs 4 --retry 3
-
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: get_branch
       - run: bundle exec slather
         env:
-          GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
+          GIT_BRANCH: ${{ steps.get_branch.outputs.branch }}
           CI_PULL_REQUEST: ${{ github.event.number }}
           COVERAGE_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -8,6 +8,7 @@ class CoverageCommand < Clamp::Command
   option ["--jenkins"], :flag, "Indicate that the builds are running on Jenkins"
   option ["--buildkite"], :flag, "Indicate that the builds are running on Buildkite"
   option ["--teamcity"], :flag, "Indicate that the builds are running on TeamCity"
+  option ["--github"], :flag, "Indicate that the builds are running on Github Actions"
 
   option ["--coveralls", "-c"], :flag, "Post coverage results to coveralls"
   option ["--simple-output", "-s"], :flag, "Output coverage results to the terminal"
@@ -91,6 +92,8 @@ class CoverageCommand < Clamp::Command
       project.ci_service = :buildkite
     elsif teamcity?
       project.ci_service = :teamcity
+    elsif github?
+      project.ci_service = :github
     end
   end
 

--- a/spec/slather/coverage_service/coveralls_spec.rb
+++ b/spec/slather/coverage_service/coveralls_spec.rb
@@ -151,6 +151,26 @@ describe Slather::CoverageService::Coveralls do
         ENV['GIT_BRANCH'] = git_branch
       end
     end
+
+    context "coverage_service is :github" do
+      before(:each) { fixtures_project.ci_service = :github }
+
+      it "should return valid json for coveralls coverage data" do
+        allow(fixtures_project).to receive(:github_job_id).and_return("9182")
+        allow(fixtures_project).to receive(:coverage_access_token).and_return("abc123")
+        allow(fixtures_project).to receive(:github_pull_request).and_return("1")
+        allow(fixtures_project).to receive(:github_build_url).and_return("https://github.com/Bruce/Wayne/actions/runs/1")
+        allow(fixtures_project).to receive(:github_git_info).and_return({ :head => { :id => "ababa123", :author_name => "bwayne", :message => "hello" }, :branch => "master" })
+        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql("{\"service_job_id\":\"9182\",\"service_name\":\"github\",\"repo_token\":\"abc123\",\"service_pull_request\":\"1\",\"service_build_url\":\"https://github.com/Bruce/Wayne/actions/runs/1\",\"git\":{\"head\":{\"id\":\"ababa123\",\"author_name\":\"bwayne\",\"message\":\"hello\"},\"branch\":\"master\"}}").excluding("source_files")
+        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.coverage_files.map(&:as_json).to_json).at_path("source_files")
+      end
+
+      it "should raise an error if there is no GITHUB_RUN_ID" do
+        allow(fixtures_project).to receive(:github_job_id).and_return(nil)
+        expect { fixtures_project.send(:coveralls_coverage_data) }.to raise_error(StandardError)
+      end
+    end
+
   end
 
   describe '#coveralls_coverage_data' do


### PR DESCRIPTION
## Implementing Github Actions

### Summary
As I needed the Github actions working for slather and coveralls I have used #459 as a base to start debugging and to find the problem. I have sent an email to coveralls support and they have answered that for github actions they are not using the coveralls repo secret, but they are using the `GITHUB_TOKEN` env secret from github actions. I have implemented that change and also I have added some more useful env variables for the report generation.

### Result
As a result the reports are working correctly using slather with github actions and coveralls. 
<img width="888" alt="Screenshot 2020-12-01 at 15 15 08" src="https://user-images.githubusercontent.com/3859373/100745480-02f56d00-33e8-11eb-93bd-9730e87fdf93.png">



### References that I have used for the development:
- #459 (thanks @troyfontaine)
- https://github.com/marketplace/actions/coveralls-github-action 
- https://docs.coveralls.io/api-reference 

### Additional info
- All the commits has been squashed
- PR may be merged with Squash and merge for clean description and reference to the PR. 

