### PR TITLE
Fixing the tests for github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,3 +284,4 @@ Please make sure to follow our general coding style and add test coverage for ne
 * [@jhersh](https://github.com/jhersh), CircleCI support.
 * [@tarbrain](https://github.com/tarbrain), Cobertura support and bugfixing.
 * [@ikhsan](https://github.com/ikhsan), html support.
+* [@martin-key](https://github.com/martin-key) and [@troyfontaine](https://github.com/troyfontaine), Github Actions support.

--- a/spec/slather/coverage_service/coveralls_spec.rb
+++ b/spec/slather/coverage_service/coveralls_spec.rb
@@ -161,7 +161,7 @@ describe Slather::CoverageService::Coveralls do
         allow(fixtures_project).to receive(:github_pull_request).and_return("1")
         allow(fixtures_project).to receive(:github_build_url).and_return("https://github.com/Bruce/Wayne/actions/runs/1")
         allow(fixtures_project).to receive(:github_git_info).and_return({ :head => { :id => "ababa123", :author_name => "bwayne", :message => "hello" }, :branch => "master" })
-        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql("{\"service_job_id\":\"9182\",\"service_name\":\"github\",\"repo_token\":\"abc123\",\"service_pull_request\":\"1\",\"service_build_url\":\"https://github.com/Bruce/Wayne/actions/runs/1\",\"git\":{\"head\":{\"id\":\"ababa123\",\"author_name\":\"bwayne\",\"message\":\"hello\"},\"branch\":\"master\"}}").excluding("source_files")
+        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql("{\"service_job_id\":\"9182\",\"service_name\":\"github\",\"repo_name\":\"\",\"repo_token\":\"abc123\",\"service_pull_request\":\"1\",\"service_build_url\":\"https://github.com/Bruce/Wayne/actions/runs/1\",\"git\":{\"head\":{\"id\":\"ababa123\",\"author_name\":\"bwayne\",\"message\":\"hello\"},\"branch\":\"master\"}}").excluding("source_files")
         expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.coverage_files.map(&:as_json).to_json).at_path("source_files")
       end
 


### PR DESCRIPTION
Here is the fix for github actions tests. I would suggest removing the commit for Slather 2.6.0 then merging this PR and making the commit again. 
It will be positive to update to the latest bundler version at some point and fixing the tests because on Bundle 2.1.4 there are few errors that need to be resolved. 