### PR TITLE
Update nokogiri to 1.11

### DIFF
--- a/slather.gemspec
+++ b/slather.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'clamp', '~> 1.3'
   spec.add_dependency 'xcodeproj', '~> 1.7'
-  spec.add_dependency 'nokogiri', '~> 1.8'
+  spec.add_dependency 'nokogiri', '~> 1.11'
   spec.add_dependency 'CFPropertyList', '>= 2.2', '< 4'
 
   spec.add_runtime_dependency 'activesupport'


### PR DESCRIPTION
Nokogiri < 1.11 is vulnerable to XML External Entity (XXE) Injection 
https://snyk.io/vuln/SNYK-RUBY-NOKOGIRI-1055008