### PR TITLE
Extract the framework target binaries from the CodeCoverageTargets.

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -582,6 +582,19 @@ module Slather
     def find_buildable_names(xcscheme)
       found_buildable_names = []
 
+      # enumerate code coverage targets
+      begin
+        code_coverage_targets = xcscheme.test_action.xml_element.elements['CodeCoverageTargets']
+        targets = code_coverage_targets.map do |node|
+          Xcodeproj::XCScheme::BuildableReference.new(node) if node.is_a?(REXML::Element)
+        end.compact
+        buildable_names = targets.each do |target|
+          found_buildable_names.push(target.buildable_name)
+        end
+      rescue
+        # just in case if there are no entries in the test action
+      end
+
       # enumerate build action entries
       begin
         xcscheme.build_action.entries.each do |entry|

--- a/spec/fixtures/FixtureFramework/FixtureFramework.h
+++ b/spec/fixtures/FixtureFramework/FixtureFramework.h
@@ -1,0 +1,19 @@
+//
+//  FixtureFramework.h
+//  FixtureFramework
+//
+//  Created by Stephen Williams on 11/03/21.
+//  Copyright © 2021 marklarr. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for FixtureFramework.
+FOUNDATION_EXPORT double FixtureFrameworkVersionNumber;
+
+//! Project version string for FixtureFramework.
+FOUNDATION_EXPORT const unsigned char FixtureFrameworkVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <FixtureFramework/PublicHeader.h>
+
+

--- a/spec/fixtures/FixtureFramework/FlashExperiment.swift
+++ b/spec/fixtures/FixtureFramework/FlashExperiment.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct FlashExperiment {
+    public let isAwesome = true
+    
+    public init() {}
+}

--- a/spec/fixtures/FixtureFramework/Info.plist
+++ b/spec/fixtures/FixtureFramework/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2021 marklarr. All rights reserved.</string>
+</dict>
+</plist>

--- a/spec/fixtures/FixtureFrameworkTests/FixtureFrameworkTests.swift
+++ b/spec/fixtures/FixtureFrameworkTests/FixtureFrameworkTests.swift
@@ -1,0 +1,34 @@
+//
+//  FixtureFrameworkTests.swift
+//  FixtureFrameworkTests
+//
+//  Created by Stephen Williams on 11/03/21.
+//  Copyright © 2021 marklarr. All rights reserved.
+//
+
+import XCTest
+@testable import FixtureFramework
+
+class FixtureFrameworkTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/spec/fixtures/FixtureFrameworkTests/FlashExperimentTests.swift
+++ b/spec/fixtures/FixtureFrameworkTests/FlashExperimentTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+import FixtureFramework
+
+class FlashExperimentTests: XCTestCase {
+    func testExample() throws {
+        let sut = FlashExperiment()
+        XCTAssertTrue(sut.isAwesome, "Your flash experiment isn't awesome!")
+    }
+}

--- a/spec/fixtures/FixtureFrameworkTests/Info.plist
+++ b/spec/fixtures/FixtureFrameworkTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/spec/fixtures/fixtures.xcodeproj/project.pbxproj
+++ b/spec/fixtures/fixtures.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		8C9A2046195965F10013B6B3 /* libfixtures.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C9A202D195965F10013B6B3 /* libfixtures.a */; };
 		8C9A204C195965F10013B6B3 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8C9A204A195965F10013B6B3 /* InfoPlist.strings */; };
 		8C9A204E195965F10013B6B3 /* fixturesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C9A204D195965F10013B6B3 /* fixturesTests.m */; };
+		B1E6981225F96B680086A3E2 /* FixtureFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = B1E6980425F96B670086A3E2 /* FixtureFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B1E6982025F96B930086A3E2 /* FlashExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E6981F25F96B930086A3E2 /* FlashExperiment.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +53,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 8C9A202C195965F10013B6B3;
 			remoteInfo = fixtures;
+		};
+		B1E6982F25F96F490086A3E2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8C9A2025195965F00013B6B3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B1E6980125F96B670086A3E2;
+			remoteInfo = FixtureFramework;
+		};
+		B1E6983725F970320086A3E2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8C9A2025195965F00013B6B3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B1E6980125F96B670086A3E2;
+			remoteInfo = FixtureFramework;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -86,6 +102,13 @@
 		8C9A2049195965F10013B6B3 /* fixturesTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "fixturesTests-Info.plist"; sourceTree = "<group>"; };
 		8C9A204B195965F10013B6B3 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		8C9A204D195965F10013B6B3 /* fixturesTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = fixturesTests.m; sourceTree = "<group>"; };
+		B1E6980225F96B670086A3E2 /* FixtureFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FixtureFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B1E6980425F96B670086A3E2 /* FixtureFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FixtureFramework.h; sourceTree = "<group>"; };
+		B1E6980525F96B670086A3E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B1E6980F25F96B680086A3E2 /* FixtureFrameworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixtureFrameworkTests.swift; sourceTree = "<group>"; };
+		B1E6981125F96B680086A3E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B1E6981F25F96B930086A3E2 /* FlashExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashExperiment.swift; sourceTree = "<group>"; };
+		B1E6982725F96BD30086A3E2 /* FlashExperimentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashExperimentTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,6 +147,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B1E697FF25F96B670086A3E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -155,6 +185,8 @@
 				8C9A2036195965F10013B6B3 /* fixtures */,
 				3773307A1CC42A58005EAF65 /* fixturesTwo */,
 				8C9A2047195965F10013B6B3 /* fixturesTests */,
+				B1E6980325F96B670086A3E2 /* FixtureFramework */,
+				B1E6980E25F96B670086A3E2 /* FixtureFrameworkTests */,
 				8C9A202F195965F10013B6B3 /* Frameworks */,
 				8C9A202E195965F10013B6B3 /* Products */,
 			);
@@ -167,6 +199,7 @@
 				8C9A2040195965F10013B6B3 /* fixturesTests.xctest */,
 				377330791CC42A58005EAF65 /* libfixturesTwo.dylib */,
 				85AE690C1E45F0F900DA2D47 /* fixturesTestsSecond.xctest */,
+				B1E6980225F96B670086A3E2 /* FixtureFramework.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -236,6 +269,26 @@
 			path = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		B1E6980325F96B670086A3E2 /* FixtureFramework */ = {
+			isa = PBXGroup;
+			children = (
+				B1E6980425F96B670086A3E2 /* FixtureFramework.h */,
+				B1E6980525F96B670086A3E2 /* Info.plist */,
+				B1E6981F25F96B930086A3E2 /* FlashExperiment.swift */,
+			);
+			path = FixtureFramework;
+			sourceTree = "<group>";
+		};
+		B1E6980E25F96B670086A3E2 /* FixtureFrameworkTests */ = {
+			isa = PBXGroup;
+			children = (
+				B1E6980F25F96B680086A3E2 /* FixtureFrameworkTests.swift */,
+				B1E6981125F96B680086A3E2 /* Info.plist */,
+				B1E6982725F96BD30086A3E2 /* FlashExperimentTests.swift */,
+			);
+			path = FixtureFrameworkTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -257,6 +310,14 @@
 				155BBCA519E9CB6700BACB13 /* Branches.h in Headers */,
 				8C0F0B451ACF44E000793B7D /* fixtures_cpp.h in Headers */,
 				8C52AEF7195AAE32008A882A /* peekaview.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B1E697FD25F96B670086A3E2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B1E6981225F96B680086A3E2 /* FixtureFramework.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -309,6 +370,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				B1E6983025F96F490086A3E2 /* PBXTargetDependency */,
 			);
 			name = fixtures;
 			productName = fixtures;
@@ -326,6 +388,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				B1E6983825F970320086A3E2 /* PBXTargetDependency */,
 				8C9A2045195965F10013B6B3 /* PBXTargetDependency */,
 			);
 			name = fixturesTests;
@@ -333,17 +396,41 @@
 			productReference = 8C9A2040195965F10013B6B3 /* fixturesTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		B1E6980125F96B670086A3E2 /* FixtureFramework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B1E6981725F96B680086A3E2 /* Build configuration list for PBXNativeTarget "FixtureFramework" */;
+			buildPhases = (
+				B1E697FD25F96B670086A3E2 /* Headers */,
+				B1E697FE25F96B670086A3E2 /* Sources */,
+				B1E697FF25F96B670086A3E2 /* Frameworks */,
+				B1E6980025F96B670086A3E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FixtureFramework;
+			productName = FixtureFramework;
+			productReference = B1E6980225F96B670086A3E2 /* FixtureFramework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		8C9A2025195965F00013B6B3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 1240;
 				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = marklarr;
 				TargetAttributes = {
 					377330781CC42A58005EAF65 = {
 						CreatedOnToolsVersion = 7.3;
+					};
+					B1E6980125F96B670086A3E2 = {
+						CreatedOnToolsVersion = 12.4;
+						LastSwiftMigration = 1240;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -352,6 +439,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 8C9A2024195965F00013B6B3;
@@ -363,6 +451,7 @@
 				377330781CC42A58005EAF65 /* fixturesTwo */,
 				8C9A203F195965F10013B6B3 /* fixturesTests */,
 				85AE68FC1E45F0F900DA2D47 /* fixturesTestsSecond */,
+				B1E6980125F96B670086A3E2 /* FixtureFramework */,
 			);
 		};
 /* End PBXProject section */
@@ -381,6 +470,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				8C9A204C195965F10013B6B3 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B1E6980025F96B670086A3E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -427,6 +523,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B1E697FE25F96B670086A3E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B1E6982025F96B930086A3E2 /* FlashExperiment.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -439,6 +543,16 @@
 			isa = PBXTargetDependency;
 			target = 8C9A202C195965F10013B6B3 /* fixtures */;
 			targetProxy = 8C9A2044195965F10013B6B3 /* PBXContainerItemProxy */;
+		};
+		B1E6983025F96F490086A3E2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B1E6980125F96B670086A3E2 /* FixtureFramework */;
+			targetProxy = B1E6982F25F96F490086A3E2 /* PBXContainerItemProxy */;
+		};
+		B1E6983825F970320086A3E2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B1E6980125F96B670086A3E2 /* FixtureFramework */;
+			targetProxy = B1E6983725F970320086A3E2 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -653,6 +767,105 @@
 			};
 			name = Release;
 		};
+		B1E6981325F96B680086A3E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = FixtureFramework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onato.FixtureFramework;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		B1E6981425F96B680086A3E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = FixtureFramework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onato.FixtureFramework;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -697,6 +910,15 @@
 			buildConfigurations = (
 				8C9A2055195965F10013B6B3 /* Debug */,
 				8C9A2056195965F10013B6B3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B1E6981725F96B680086A3E2 /* Build configuration list for PBXNativeTarget "FixtureFramework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B1E6981325F96B680086A3E2 /* Debug */,
+				B1E6981425F96B680086A3E2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/spec/fixtures/fixtures.xcodeproj/xcshareddata/xcschemes/fixtures.xcscheme
+++ b/spec/fixtures/fixtures.xcodeproj/xcshareddata/xcschemes/fixtures.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B1E6980125F96B670086A3E2"
+            BuildableName = "FixtureFramework.framework"
+            BlueprintName = "FixtureFramework"
+            ReferencedContainer = "container:fixtures.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,8 +50,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +70,6 @@
             ReferencedContainer = "container:fixtures.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -70,6 +77,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8C9A202C195965F10013B6B3"
+            BuildableName = "libfixtures.a"
+            BlueprintName = "fixtures"
+            ReferencedContainer = "container:fixtures.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/spec/fixtures/fixtures.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/spec/fixtures/fixtures.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -243,8 +243,9 @@ describe Slather::Project do
       allow(fixtures_project).to receive(:scheme).and_return("fixtures")
       fixtures_project.send(:configure_binary_file)
       binary_file_location = fixtures_project.send(:binary_file)
-      expect(binary_file_location.count).to eq(1)
-      expect(binary_file_location.first).to end_with("Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests")
+      expect(binary_file_location.count).to eq(2)
+      expect(binary_file_location.first).to end_with("Debug/FixtureFramework.framework/Versions/A/FixtureFramework")
+      expect(binary_file_location.last).to end_with("Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests")
     end
 
     it "should find the product path provided a workspace and scheme" do
@@ -252,8 +253,9 @@ describe Slather::Project do
       allow(fixtures_project).to receive(:scheme).and_return("fixtures")
       fixtures_project.send(:configure_binary_file)
       binary_file_location = fixtures_project.send(:binary_file)
-      expect(binary_file_location.count).to eq(1)
-      expect(binary_file_location.first).to end_with("Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests")
+      expect(binary_file_location.count).to eq(2)
+      expect(binary_file_location.first).to end_with("Debug/FixtureFramework.framework/Versions/A/FixtureFramework")
+      expect(binary_file_location.last).to end_with("Debug/fixturesTests.xctest/Contents/MacOS/fixturesTests")
     end
 
     it "should find the product path for a scheme with no buildable products" do


### PR DESCRIPTION
This PR enables code coverage from framework targets to be extracted.

Issue: #432

This should also take care of #440.