### PR TITLE
Consider the case where multiple phrases appear in line

### DIFF
--- a/lib/slather/coverage_service/html_output.rb
+++ b/lib/slather/coverage_service/html_output.rb
@@ -201,7 +201,7 @@ module Slather
                           end
                           current_line = line
                           regions.each do |region|
-                            covered, remainder = current_line.split(region)
+                            covered, remainder = current_line.split(region, 2)
                             cov.code(covered, :class => "objc")
                             cov.code(region, :class => "objc missed")
                             current_line = remainder


### PR DESCRIPTION
This PR is intended to fix #480 

## error cause

If `line` is `"if(_var && _var.foo) {"` and `regions` is `["_var", "_var.foo", "{"]`, 

After the first loop,

expected:
`reminder` should be `" && _var.foo) {"`

actual:
`reminder` is `" && "`
