### PR TITLE
Fix for multiple region data

### DIFF
--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -221,7 +221,7 @@ module Slather
             # if the region wrapped to a new line before ending, put nil to indicate it didnt end on this line
             region_end = line == current_line ? col - region_start : nil
             if branch_region_data.key?(current_line)
-              branch_region_data[current_line] = branch_region_data[current_line] + [region_start, region_end]
+              branch_region_data[current_line] << [region_start, region_end]
             else
               branch_region_data[current_line] = [[region_start, region_end]]
             end

--- a/spec/slather/profdata_coverage_spec.rb
+++ b/spec/slather/profdata_coverage_spec.rb
@@ -167,6 +167,10 @@ describe Slather::ProfdataCoverageFile do
       profdata_coverage_file.segments = [[19, 9, 0, true, false], [19, 20, 1, true, false]]
       expect(profdata_coverage_file.branch_region_data[19]).to eq([[8,11]])
     end
+    it "should have two missing region data for line 19" do
+      profdata_coverage_file.segments = [[19, 9, 0, true, false], [19, 20, 1, true, false], [19, 30, 0, true, false], [19, 40, 1, true, true]]
+      expect(profdata_coverage_file.branch_region_data[19]).to eq([[8,11], [29,10]])
+    end
   end
 
   describe "#ignored" do


### PR DESCRIPTION
This PR is intended to fix #481

If we want `[[a,b],[c,d]]` from `[[a,b]]` and `[c,d]`, we should use `<<`.