### PR TITLE
Add relevant lines count and tested lines count to html report

### DIFF
--- a/lib/slather/coverage_service/html_output.rb
+++ b/lib/slather/coverage_service/html_output.rb
@@ -88,9 +88,9 @@ module Slather
             cov.span "Total Coverage : "
             cov.span decimal_f(percentage) + '%', :class => class_for_coverage_percentage(percentage), :id => "total_coverage"
             cov.span " ("
-            cov.span total_relevant_lines, :id => "total_relevant_lines"
-            cov.span " of "
             cov.span total_tested_lines, :id => "total_tested_lines"
+            cov.span " of "
+            cov.span total_relevant_lines, :id => "total_relevant_lines"
             cov.span " lines)"
           }
 

--- a/lib/slather/coverage_service/html_output.rb
+++ b/lib/slather/coverage_service/html_output.rb
@@ -87,12 +87,22 @@ module Slather
             percentage = (total_tested_lines / total_relevant_lines.to_f) * 100.0
             cov.span "Total Coverage : "
             cov.span decimal_f(percentage) + '%', :class => class_for_coverage_percentage(percentage), :id => "total_coverage"
+            cov.span " ("
+            cov.span total_relevant_lines, :id => "total_relevant_lines"
+            cov.span " of "
+            cov.span total_tested_lines, :id => "total_tested_lines"
+            cov.span " lines)"
           }
 
           cov.h4 {
             percentage = (total_branches_tested / total_relevant_branches.to_f) * 100.0
             cov.span "Total Branch Coverage : "
             cov.span decimal_f(percentage) + '%', :class => class_for_coverage_percentage(percentage), :id => "total_coverage"
+            cov.span " ("
+            cov.span total_branches_tested, :id => "total_branches_tested"
+            cov.span " of "
+            cov.span total_relevant_branches, :id => "total_relevant_branches"
+            cov.span " lines)"
           }
 
           cov.input(:class => "search", :placeholder => "Search")


### PR DESCRIPTION
### Background story
In the project where multiple modules are created, having just the code coverage percentage per module is not enough information to calculate the overall code coverage for the whole project. Additional information about total number of lines and total number of lines tested is required.

### PR description
In this PR additional data regarding total number of lines and total number of lines tested is added to html report.

### Screen shot
<img width="1596" alt="Zrzut ekranu 2021-04-24 o 11 21 10" src="https://user-images.githubusercontent.com/73116686/115954064-2fbd3480-a4ef-11eb-8bf0-300daf7c8135.png">
