### PR TITLE
If repo_token, no need for service_name

### DIFF
--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -157,6 +157,12 @@ module Slather
       private :github_build_url
 
       def coveralls_coverage_data
+        unless coverage_access_token.nil?
+          return {
+            :repo_token => coverage_access_token,
+            :source_files => coverage_files.map(&:as_json)
+          }.to_json
+        end
         if ci_service == :travis_ci || ci_service == :travis_pro
           if travis_job_id
             if ci_service == :travis_ci


### PR DESCRIPTION
`service_job_id` and `service_name` are just required in case _Coveralls_ gives support to that particular CI. 

If you see `xcov` it's enough by sending `repo_token`. You can find a sample payload [here](https://github.com/fastlane-community/xcov/issues/143). This way, any CI can be supported by `slather` as long as you specify `repo_token` in your environment or `.slather.yml`