### PR TITLE
Bump xcodeproj to 1.21

### DIFF
--- a/slather.gemspec
+++ b/slather.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'equivalent-xml', '~> 0.6'
 
   spec.add_dependency 'clamp', '~> 1.3'
-  spec.add_dependency 'xcodeproj', '~> 1.7'
+  spec.add_dependency 'xcodeproj', '~> 1.20.0'
   spec.add_dependency 'nokogiri', '~> 1.11'
   spec.add_dependency 'CFPropertyList', '>= 2.2', '< 4'
 

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'equivalent-xml', '~> 0.6'
 
   spec.add_dependency 'clamp', '~> 1.3'
-  spec.add_dependency 'xcodeproj', '~> 1.20.0'
+  spec.add_dependency 'xcodeproj', '~> 1.21.0'
   spec.add_dependency 'nokogiri', '~> 1.11'
   spec.add_dependency 'CFPropertyList', '>= 2.2', '< 4'
 

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'equivalent-xml', '~> 0.6'
 
   spec.add_dependency 'clamp', '~> 1.3'
-  spec.add_dependency 'xcodeproj', '~> 1.21.0'
+  spec.add_dependency 'xcodeproj', '~> 1.21'
   spec.add_dependency 'nokogiri', '~> 1.11'
   spec.add_dependency 'CFPropertyList', '>= 2.2', '< 4'
 


### PR DESCRIPTION
👋 Hi there!

Between CocoaPods and Fastlane using more recent versions of xcodeproj I’m blocked from using Slather 2.7.1, the latest release.

This PR just bumps Slather’s xcodeproj dependency from 1.7 to 1.21. Easy peasy.

Let me know if there’s documentation or versioning or anything else I should add here. Thanks!