### PR TITLE
Bump nokogiri version

### DIFF
--- a/slather.gemspec
+++ b/slather.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'clamp', '~> 1.3'
   spec.add_dependency 'xcodeproj', '~> 1.7'
-  spec.add_dependency 'nokogiri', '~> 1.11'
+  spec.add_dependency 'nokogiri', '~> 1.12'
   spec.add_dependency 'CFPropertyList', '>= 2.2', '< 4'
 
   spec.add_runtime_dependency 'activesupport'


### PR DESCRIPTION
There is a high severity warning about versions of nokogiri lower than 1.12.5. The GitHub report can be found here: https://github.com/advisories/GHSA-2rr5-8q37-2w7h

This pull request bumps the dependency to 1.12, allowing the fixed 1.12.5 version to be used.