### PR TITLE
Support "other" CI servers

### DIFF
--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -264,7 +264,15 @@ module Slather
             raise StandardError, "Environment variable `GITHUB_RUN_ID` not set.  Is this running on github build?"
           end
         else
-          raise StandardError, "No support for ci named #{ci_service}"
+          {
+              :service_job_id => ENV['CI_BUILD_NUMBER'],
+              :service_name => ENV['CI_NAME'] ? ENV['CI_NAME'] : 'other',
+              :repo_token => coverage_access_token,
+              :source_files => coverage_files.map(&:as_json),
+              :service_build_url => ENV['CI_BUILD_URL'],
+              :service_pull_request => ENV['CI_PULL_REQUEST'],
+              :service_branch => ENV['CI_BRANCH']
+            }.to_json
         end
       end
       private :coveralls_coverage_data

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -375,7 +375,7 @@ module Slather
     end
 
     def configure_ci_service
-      self.ci_service ||= (self.class.yml["ci_service"] || :travis_ci)
+      self.ci_service ||= (self.class.yml["ci_service"] || :unknown)
     end
 
     def configure_input_format


### PR DESCRIPTION
According to [Coveralls Docs](https://docs.coveralls.io/supported-ci-services), you can _INSERT YOUR CI HERE_ by exporting from the CI server the following variables:
```
CI_NAME
CI_BUILD_NUMBER
CI_BUILD_URL
CI_BRANCH
CI_PULL_REQUEST (optional)
```
This PR takes those variables from the environment and sets `:unknown` as the default `ci_server`