### PR TITLE
support Coveralls parallel runs

### DIFF
--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -184,6 +184,11 @@ module Slather
       end
       private :github_build_url
 
+      def is_parallel
+        ENV['IS_PARALLEL'] != nil
+      end
+      private :is_parallel
+
       def coveralls_coverage_data
         if ci_service == :travis_ci || ci_service == :travis_pro
           if travis_job_id
@@ -286,7 +291,8 @@ module Slather
               :source_files => coverage_files.map(&:as_json),
               :service_build_url => github_build_url,
               :service_pull_request => github_pull_request,
-              :git => github_git_info
+              :git => github_git_info,
+              :parallel => is_parallel
             }.to_json
           else
             raise StandardError, "Environment variable `GITHUB_RUN_ID` not set.  Is this running on github build?"

--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -188,7 +188,7 @@ module Slather
         if ci_service == :travis_ci || ci_service == :travis_pro
           if travis_job_id
             if ci_service == :travis_ci
-              
+
               if coverage_access_token.to_s.strip.length > 0
                 raise StandardError, "Access token is set. Uploading coverage data for public repositories doesn't require an access token."
               end
@@ -198,7 +198,7 @@ module Slather
                 :service_name => "travis-ci",
                 :source_files => coverage_files.map(&:as_json)
               }.to_json
-            elsif ci_service == :travis_pro              
+            elsif ci_service == :travis_pro
 
               if coverage_access_token.to_s.strip.length == 0
                 raise StandardError, "Access token is not set. Uploading coverage data for private repositories requires an access token."
@@ -332,8 +332,8 @@ module Slather
 
           curl_result = `curl -s --form json_file=@#{f.path} #{coveralls_api_jobs_path}`
 
-          if curl_result.is_a? String 
-            curl_result_json = JSON.parse(curl_result)          
+          if curl_result.is_a? String
+            curl_result_json = JSON.parse(curl_result)
 
             if curl_result_json["error"]
               error_message = curl_result_json["message"]

--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -189,6 +189,11 @@ module Slather
       end
       private :is_parallel
 
+      def github_job_name
+        ENV['GITHUB_JOB']
+      end
+      private :github_job_name
+
       def coveralls_coverage_data
         if ci_service == :travis_ci || ci_service == :travis_pro
           if travis_job_id
@@ -292,7 +297,8 @@ module Slather
               :service_build_url => github_build_url,
               :service_pull_request => github_pull_request,
               :git => github_git_info,
-              :parallel => is_parallel
+              :parallel => is_parallel,
+              :flag_name => github_job_name
             }.to_json
           else
             raise StandardError, "Environment variable `GITHUB_RUN_ID` not set.  Is this running on github build?"


### PR DESCRIPTION
add IS_PARALLEL environment to allow parallel
and `flag_name` as GitHub job name

> parallel | *Boolean* OPTIONAL If this is set, the build will not be considered done until a webhook has been sent to https://coveralls.io/webhook?repo_token=…
> -- | --
> flag_name | *String* OPTIONAL If this is set, the job being reported will be named in the view and have it’s own independent status reported to your VCS provider.
> 
