### PR TITLE
Start using `File.exist?` for deprecated `File.exists?` which got removed in ruby@3.2

### DIFF
--- a/lib/slather/coverage_file.rb
+++ b/lib/slather/coverage_file.rb
@@ -51,7 +51,7 @@ module Slather
           gcov_files_created = gcov_output.scan(/creating '(.+\..+\.gcov)'/)
 
           gcov_file_name = "./#{source_file_pathname.basename}.gcov"
-          if File.exists?(gcov_file_name)
+          if File.exist?(gcov_file_name)
             gcov_data = File.new(gcov_file_name).read
           else
             gcov_data = ""

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -208,7 +208,7 @@ module Slather
 
     def profdata_coverage_dir
       @profdata_coverage_dir ||= begin
-        raise StandardError, "The specified build directory (#{self.build_directory}) does not exist" unless File.exists?(self.build_directory)
+        raise StandardError, "The specified build directory (#{self.build_directory}) does not exist" unless File.exist?(self.build_directory)
         dir = nil
         if self.scheme
           dir = Dir[File.join(build_directory,"/**/CodeCoverage/#{self.scheme}")].first
@@ -503,7 +503,7 @@ module Slather
           end
         end
 
-        raise StandardError, "No scheme named '#{self.scheme}' found in #{self.path}" unless File.exists? xcscheme_path
+        raise StandardError, "No scheme named '#{self.scheme}' found in #{self.path}" unless File.exist? xcscheme_path
 
         xcscheme = Xcodeproj::XCScheme.new(xcscheme_path)
 

--- a/spec/slather/coverage_service/cobertura_xml_spec.rb
+++ b/spec/slather/coverage_service/cobertura_xml_spec.rb
@@ -45,7 +45,7 @@ describe Slather::CoverageService::CoberturaXmlOutput do
       fixtures_project.post
 
       filepath = "#{fixtures_project.output_directory}/cobertura.xml"
-      expect(File.exists?(filepath)).to be_truthy
+      expect(File.exist?(filepath)).to be_truthy
 
       FileUtils.rm_rf(fixtures_project.output_directory)
     end

--- a/spec/slather/coverage_service/json_spec.rb
+++ b/spec/slather/coverage_service/json_spec.rb
@@ -35,7 +35,7 @@ describe Slather::CoverageService::JsonOutput do
       fixtures_project.post
 
       filepath = "#{fixtures_project.output_directory}/report.json"
-      expect(File.exists?(filepath)).to be_truthy
+      expect(File.exist?(filepath)).to be_truthy
 
       FileUtils.rm_rf(fixtures_project.output_directory)
     end

--- a/spec/slather/coverage_service/llvm_cov_spec.rb
+++ b/spec/slather/coverage_service/llvm_cov_spec.rb
@@ -38,7 +38,7 @@ describe Slather::CoverageService::LlvmCovOutput do
       fixtures_project.post
 
       filepath = "#{fixtures_project.output_directory}/report.llcov"
-      expect(File.exists?(filepath)).to be_truthy
+      expect(File.exist?(filepath)).to be_truthy
 
       FileUtils.rm_rf(fixtures_project.output_directory)
     end

--- a/spec/slather/coverage_service/sonarqube_xml_spec.rb
+++ b/spec/slather/coverage_service/sonarqube_xml_spec.rb
@@ -38,7 +38,7 @@ describe Slather::CoverageService::SonarqubeXmlOutput do
       fixtures_project.post
 
       filepath = "#{fixtures_project.output_directory}/sonarqube-generic-coverage.xml"
-      expect(File.exists?(filepath)).to be_truthy
+      expect(File.exist?(filepath)).to be_truthy
 
       FileUtils.rm_rf(fixtures_project.output_directory)
     end


### PR DESCRIPTION
### Background context
- `File.exists?` has been deprecated since Ruby 2.1.0.
- and [ruby@3.2 removed File.exists?](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/), therefore Slather is now failing, when using ruby@3.2
- Fixes https://github.com/SlatherOrg/slather/issues/529

### PR description
- I basically searched for all occurrences of File.exists? and
- Now start using `File.exist?`

### Screenshot
<img width="824" alt="Screenshot 2023-01-11 at 20 50 27" src="https://user-images.githubusercontent.com/5364500/211904444-078c8deb-dc64-4d25-830c-cc76c8d8cd30.png">
