### PR TITLE
Adding `--cdn-assets` flag that loads the Logo, CSS and JS files from jsdelivr CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ $ slather coverage --html --scheme YourXcodeSchemeName path/to/project.xcodeproj
 
 This will make a directory named `html` in your root directory (unless `--output-directory` is specified) and will generate all the reports as static html pages inside the directory. It will print out the report's path by default, but you can also specify `--show` flag to open it in your browser automatically.
 
+By default, the generated HTML will reference locally hosted assets (js, css). You can specify the `--cdn-assets` to specify that you prefer for the generated HTML to use externally hosted assets. This can be useful if publishing the HTML file as a build artifact. 
+
 ### TeamCity Reporting
 
 To report the coverage statistics to TeamCity:

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -19,6 +19,7 @@ class CoverageCommand < Clamp::Command
   option ["--json"], :flag, "Output coverage results as simple JSON"
   option ["--html"], :flag, "Output coverage results as static html pages"
   option ["--show"], :flag, "Indicate that the static html pages will open automatically"
+  option ["--cdn-assets"], :flag, "Indicate that the static html pages will load assets from a CDN"
 
   option ["--build-directory", "-b"], "BUILD_DIRECTORY", "The directory where gcno files will be written to. Defaults to derived data."
   option ["--source-directory"], "SOURCE_DIRECTORY", "The directory where your source files are located."
@@ -126,6 +127,7 @@ class CoverageCommand < Clamp::Command
     elsif html?
       project.coverage_service = :html
       project.show_html = show?
+      project.cdn_assets = cdn_assets?
     elsif json?
       project.coverage_service = :json
     elsif sonarqube_xml?

--- a/lib/slather/coverage_service/html_output.rb
+++ b/lib/slather/coverage_service/html_output.rb
@@ -233,10 +233,17 @@ module Slather
       end
 
       def generate_html_template(title, is_index, is_file_empty)
-        logo_path = "logo.jpg"
-        css_path = "slather.css"
-        highlight_js_path = "highlight.pack.js"
-        list_js_path = "list.min.js"
+        if cdn_assets
+          logo_path = "https://cdn.jsdelivr.net/gh/SlatherOrg/slather/docs/logo.jpg"
+          css_path = "https://cdn.jsdelivr.net/gh/SlatherOrg/slather/assets/slather.css"
+          highlight_js_path = "https://cdn.jsdelivr.net/gh/SlatherOrg/slather/assets/highlight.pack.js"
+          list_js_path = "https://cdn.jsdelivr.net/gh/SlatherOrg/slather/assets/list.min.js"
+        else
+          logo_path = "logo.jpg"
+          css_path = "slather.css"
+          highlight_js_path = "highlight.pack.js"
+          list_js_path = "list.min.js"
+        end
 
         builder = Nokogiri::HTML::Builder.new do |doc|
           doc.html {

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -44,7 +44,7 @@ module Slather
   class Project < Xcodeproj::Project
 
     attr_accessor :build_directory, :ignore_list, :ci_service, :coverage_service, :coverage_access_token, :source_directory,
-      :output_directory, :xcodeproj, :show_html, :verbose_mode, :input_format, :scheme, :workspace, :binary_file, :binary_basename, :arch, :source_files,
+      :output_directory, :xcodeproj, :show_html, :cdn_assets, :verbose_mode, :input_format, :scheme, :workspace, :binary_file, :binary_basename, :arch, :source_files,
       :decimals, :llvm_version, :configuration
 
     alias_method :setup_for_coverage, :slather_setup_for_coverage

--- a/lib/slather/version.rb
+++ b/lib/slather/version.rb
@@ -1,3 +1,3 @@
 module Slather
-  VERSION = '2.7.4' unless defined?(Slather::VERSION)
+  VERSION = '2.7.5' unless defined?(Slather::VERSION)
 end


### PR DESCRIPTION
I have worked on a few projects that use slather in the last few years. I have always accepted that the HTML report viewing experience will be sub-par because there are no CSS and JS files once the report (index.html) is deployed to Azure DevOps or Bitrise (I'm sure others have similar limitations).

I propose that instead of referencing the local`logo.jpg`,`list.min.js, `highlight.pack.js` and `slather.css` relative to the HTML report, the report should instead reference a Web/CDN version. This way HTML reports will be feature-rich when deployed to these services as build artifacts.

1. No change in default behavior. The new flag is opt-in.
2. Reads slather logo, CSS and JS from the master branch of SlatherOrg GitHub project using jsdelivr CDN. Could consider making it more dynamic and configurable later in the future. EG adding support for tags or different forks.

Relates to: https://github.com/SlatherOrg/slather/issues/536

First time I've written any ruby code - sorry if I've broken any conventions and/or messed up on the versioning for this PR. Let me know what I can do to get this merged ASAP :) 