### PR TITLE
ProfdataCoverageFile: fix NoMethodError in source_file_pathname

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -185,7 +185,7 @@ module Slather
         if paths_to_segments.key?(coverage_file.source_file_pathname)
           coverage_file.segments = paths_to_segments[coverage_file.source_file_pathname]
         end
-        !coverage_file.ignored? ? coverage_file : nil
+        coverage_file.source_file_pathname && !coverage_file.ignored? ? coverage_file : nil
       end.compact
     end
     private :create_coverage_files
@@ -640,7 +640,7 @@ module Slather
 
     def find_source_files
       source_files = load_option_array("source_files")
-      return if source_files.nil?
+      return [] if source_files.nil?
 
       current_dir = Pathname("./").realpath
       paths = source_files.flat_map { |pattern| Dir.glob(pattern) }.uniq


### PR DESCRIPTION
Slather::Project::find_source_files previously could return nil, which would cause ProfdataCoverageFile::source_file_pathname to fail trying to call `each` on the nil value.

Update Slather::Project::find_source_files to return an empty list instead of nil. We then also need to update `create_coverage_files` to check whether source_file_pathname returns nil and if so, not include that coverage file.

Full stack trace:

```
.../.gem/ruby/3.2.1/gems/slather-2.7.4/lib/slather/profdata_coverage_file.rb:50:in `source_file_pathname': undefined method `each' for nil:NilClass (NoMethodError)

          project.find_source_files.each do |file|
                                   ^^^^^
	from .../.gem/ruby/3.2.1/gems/slather-2.7.4/lib/slather/project.rb:185:in `block in create_coverage_files'
	from .../.gem/ruby/3.2.1/gems/slather-2.7.4/lib/slather/project.rb:180:in `map'
	from .../.gem/ruby/3.2.1/gems/slather-2.7.4/lib/slather/project.rb:180:in `create_coverage_files'
	from .../.gem/ruby/3.2.1/gems/slather-2.7.4/lib/slather/project.rb:153:in `create_coverage_files_for_binary'
	from .../.gem/ruby/3.2.1/gems/slather-2.7.4/lib/slather/project.rb:125:in `block in profdata_coverage_files'
	from .../.gem/ruby/3.2.1/gems/slather-2.7.4/lib/slather/project.rb:123:in `each'
	from .../.gem/ruby/3.2.1/gems/slather-2.7.4/lib/slather/project.rb:123:in `profdata_coverage_files'
	from .../.gem/ruby/3.2.1/gems/slather-2.7.4/lib/slather/project.rb:98:in `coverage_files'
	from .../.gem/ruby/3.2.1/gems/slather-2.7.4/lib/slather/coverage_service/sonarqube_xml_output.rb:18:in `post'
	from .../.gem/ruby/3.2.1/gems/slather-2.7.4/lib/slather/command/coverage_command.rb:101:in `post'
	from .../.gem/ruby/3.2.1/gems/slather-2.7.4/lib/slather/command/coverage_command.rb:61:in `execute'
	from .../.gem/ruby/3.2.1/gems/clamp-1.3.2/lib/clamp/command.rb:66:in `run'
	from .../.gem/ruby/3.2.1/gems/clamp-1.3.2/lib/clamp/subcommand/execution.rb:18:in `execute'
	from .../.gem/ruby/3.2.1/gems/clamp-1.3.2/lib/clamp/command.rb:66:in `run'
	from .../.gem/ruby/3.2.1/gems/clamp-1.3.2/lib/clamp/command.rb:140:in `run'
	from .../.gem/ruby/3.2.1/gems/slather-2.7.4/bin/slather:17:in `<top (required)>'
	from .../.gem/ruby/3.2.1/bin/slather:25:in `load'
	from .../.gem/ruby/3.2.1/bin/slather:25:in `<main>'
```