### PR TITLE
chore: handle include globs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,20 @@ Run this command to enable the `Generate Test Coverage` and `Instrument Program 
 ```sh
 $ slather setup path/to/project.xcodeproj
 ```
+## General Usage Notes
+### Commandline Arguments Win
+When using both a config file (`.slather.yml`) and providing arguments via the commandline,
+the arguments will take precedence over the matching setting in the config file.
 
+### `ignore` always wins over `source-files`
+When defining both files that should be ignored (`--ignore`, ignore) and source files to include (`--source-files`, source_files),
+the ignore list is checked first. If the file being scanned matches a glob in the ignore list, it will not be included. In this case, the
+source_file list is not checked.
+
+If the file being scanned is not in the ignore list, and source_file has been defined, the source_file list is
+checked. If the source file matches a glob, it will be included.
+
+## CI Integration
 ### Usage with Codecov
 
 Login to [Codecov](https://codecov.io/) (no need to activate a repository, this happens automatically). Right now, `slather` supports Codecov via **all** supported CI providers [listed here](https://github.com/codecov/codecov-bash#ci-providers).

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -174,7 +174,7 @@ class CoverageCommand < Clamp::Command
   end
 
   def setup_source_files
-    project.source_files = source_files if !source_files.empty?
+    project.source_files = source_files_list if !source_files_list.empty?
   end
 
   def setup_decimals

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -174,7 +174,7 @@ class CoverageCommand < Clamp::Command
   end
 
   def setup_source_files
-    project.source_files = source_files_list if !source_files_list.empty?
+    project.source_files = source_files if !source_files.empty?
   end
 
   def setup_decimals

--- a/lib/slather/coverage_info.rb
+++ b/lib/slather/coverage_info.rb
@@ -80,5 +80,11 @@ module Slather
       end
     end
 
+    def include_file?
+      project.source_files.any? do |include|
+        File.fnmatch(include, source_file_pathname_relative_to_repo_root)
+      end
+    end
+
   end
 end

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -246,16 +246,14 @@ module Slather
     private :supported_file_extensions
 
     def ignored?
-      # This indicates a llvm-cov coverage warning (occurs if a passed in source file 
-      # is not covered or with ccache in some cases).
-      ignore = source_file_pathname.to_s.end_with? "isn't covered."
+      path = source_file_pathname.to_s
 
-      if !ignore
-        # Ignore source files inside of platform SDKs
-        ignore = (/Xcode.*\.app\/Contents\/Developer\/Platforms/ =~ source_file_pathname.to_s) != nil
-      end
+      return true if path.end_with?("isn't covered.")
+      return true if path.include?("/Xcode.*\.app\/Contents\/Developer\/Platforms")
+      return true if path.include?("/SourcePackages/checkouts")
+      return true if path.include?("/DerivedSources")
 
-      ignore ? ignore : super
+      super
     end
   end
 end

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -250,8 +250,6 @@ module Slather
 
       return true if path.end_with?("isn't covered.")
       return true if path.include?("/Xcode.*\.app\/Contents\/Developer\/Platforms")
-      return true if path.include?("/SourcePackages/checkouts")
-      return true if path.include?("/DerivedSources")
 
       super
     end

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -249,7 +249,7 @@ module Slather
       path = source_file_pathname.to_s
 
       # This indicates a llvm-cov coverage warning (occurs if a passed in source file
-      # is not covered or with ccache in some cases).
+      # is not covered or with cache in some cases).
       return true if path.end_with?("isn't covered.")
       # Ignore source files inside of platform SDKs
       return true if path.include?("/Xcode.*\.app\/Contents\/Developer\/Platforms")

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -248,7 +248,10 @@ module Slather
     def ignored?
       path = source_file_pathname.to_s
 
+      # This indicates a llvm-cov coverage warning (occurs if a passed in source file
+      # is not covered or with ccache in some cases).
       return true if path.end_with?("isn't covered.")
+      # Ignore source files inside of platform SDKs
       return true if path.include?("/Xcode.*\.app\/Contents\/Developer\/Platforms")
 
       super

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -383,7 +383,6 @@ module Slather
 
     def configure_source_files
       self.source_files ||= [(self.class.yml["source_files"] || [])].flatten
-      puts self.source_files.to_json
     end
 
     def configure_ci_service

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -185,7 +185,7 @@ module Slather
         if paths_to_segments.key?(coverage_file.source_file_pathname)
           coverage_file.segments = paths_to_segments[coverage_file.source_file_pathname]
         end
-        !coverage_file.ignored? ? coverage_file : nil
+        !coverage_file.ignored? && coverage_file.include_file? ? coverage_file : nil
       end.compact
     end
     private :create_coverage_files
@@ -341,6 +341,7 @@ module Slather
         configure_arch
         configure_binary_file
         configure_decimals
+        configure_source_files
 
         self.llvm_version = `xcrun llvm-cov --version`.match(/LLVM version ([\d\.]+)/).captures[0]
       rescue => e
@@ -378,6 +379,11 @@ module Slather
 
     def configure_ignore_list
       self.ignore_list ||= [(self.class.yml["ignore"] || [])].flatten
+    end
+
+    def configure_source_files
+      self.source_files ||= [(self.class.yml["source_files"] || [])].flatten
+      puts self.source_files.to_json
     end
 
     def configure_ci_service


### PR DESCRIPTION
This update introduces a mechanism that handles the globs specified in the source_files configuration.

* It adds new functionality to include source files matching the specified glob patterns and allows the configuration of these source files. Files not matching a glob defined in `source_files` are excluded.
* Additionally, it refactors the ignored file code in the profdata_coverage_file class to streamline the condition checks.

At it's most basic, the file is checked to see if it's ignore and, if it isn't and there are source_files defined, tested to see if it should be included in the scan.