### PR TITLE
Fix #558: cobertura.sourceforge.net should use https instead of http.

### DIFF
--- a/lib/slather/coverage_service/cobertura_xml_output.rb
+++ b/lib/slather/coverage_service/cobertura_xml_output.rb
@@ -171,7 +171,7 @@ module Slather
           xml.doc.create_internal_subset(
             'coverage',
             nil,
-            "http://cobertura.sourceforge.net/xml/coverage-04.dtd"
+            "https://cobertura.sourceforge.net/xml/coverage-04.dtd"
           )
           xml.coverage do
             xml.sources do

--- a/spec/fixtures/cobertura.xml
+++ b/spec/fixtures/cobertura.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<!DOCTYPE coverage SYSTEM "https://cobertura.sourceforge.net/xml/coverage-04.dtd">
 <coverage line-rate="0.7500000000000000" branch-rate="0.6410256410256411" lines-covered="60" lines-valid="80" branches-covered="25" branches-valid="39" complexity="0.0" timestamp="1614041230" version="Slather 2.6.1">
   <sources>
     <source>/Users/hborawski/sandbox/slather</source>


### PR DESCRIPTION
Use `https` when writing the dtd link to the cobertura.xml file. Fixes #558 