### PR TITLE
fix #561: Set a default true return value for when source_files is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+* coverage_info.include_files? needs a default true return value for when source_files is empty.
+  [jarrodlombardo-EventBase](https://github.com/jarrodlombardo-EventBase)
+  [#561](https://github.com/SlatherOrg/slather/issues/561)
+
 ## v2.8.1
 
 * cobertura.sourceforge.net should use https instead of http

--- a/lib/slather/coverage_info.rb
+++ b/lib/slather/coverage_info.rb
@@ -81,9 +81,12 @@ module Slather
     end
 
     def include_file?
+      rv = true # default true return value to fix https://github.com/SlatherOrg/slather/issues/561
       project.source_files.any? do |include|
-        File.fnmatch(include, source_file_pathname_relative_to_repo_root)
+        rv = File.fnmatch(include, source_file_pathname_relative_to_repo_root)
       end
+
+      rv
     end
 
   end


### PR DESCRIPTION
`coverage_info.include_files?` needs a default `true` return value for when source_files is empty.