### PR TITLE
Fix #558 404 dtd url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,12 @@ tmp
 mkmf.log
 .vendor
 .ruby-version
+cobertura.xml
+.gutter.json
+html
+*.gcda
+*.gcno
+
 # Xcode
 #
 *.pbxuser
@@ -40,11 +46,13 @@ DerivedData
 *.ipa
 *.xcuserstate
 *.DS_Store
-cobertura.xml
-.gutter.json
-html
-*.gcda
-*.gcno
+
+# VSCode IDE
+.vscode/
+.rdbgrc*
+
+# python
+.venv/
 
 # JetBrains IDE
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased 
+
+* update cobertura DTD to a working URL.
+  [jarrodlombardo-EventBase](https://github.com/jarrodlombardo-EventBase)
+
 ## v2.8.2
 
 * coverage_info.include_files? needs a default true return value for when source_files is empty.

--- a/lib/slather/coverage_service/cobertura_xml_output.rb
+++ b/lib/slather/coverage_service/cobertura_xml_output.rb
@@ -171,7 +171,7 @@ module Slather
           xml.doc.create_internal_subset(
             'coverage',
             nil,
-            "https://cobertura.sourceforge.net/xml/coverage-04.dtd"
+            "https://raw.githubusercontent.com/cobertura/cobertura/master/cobertura/src/site/htdocs/xml/coverage-04.dtd"
           )
           xml.coverage do
             xml.sources do


### PR DESCRIPTION
`https://cobertura.sourceforge.net/xml/coverage-04.dtd` 404s, so any tool that tries to actually validate the xml with the dtd will fail.
`https://raw.githubusercontent.com/cobertura/cobertura/master/cobertura/src/site/htdocs/xml/coverage-04.dtd` is the file that used to be published to SourceForge but still exists. 

Output cobertura.xml validate now with the new url.