### PR TITLE
Update Xcodeproj to 1.27.1

### DIFF
--- a/slather.gemspec
+++ b/slather.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'equivalent-xml', '~> 0.6'
 
   spec.add_dependency 'clamp', '~> 1.3'
-  spec.add_dependency 'xcodeproj', '~> 1.25'
+  spec.add_dependency 'xcodeproj', '~> 1.27'
   spec.add_dependency 'nokogiri', '>= 1.14.3'
   spec.add_dependency 'CFPropertyList', '>= 2.2', '< 4'
 


### PR DESCRIPTION
Hello,

Xcodeproj recently published a new version that adds [support to Xcode 16 new folder project structure](https://github.com/CocoaPods/Xcodeproj/pull/985).

Before that, we faced some issues when trying to generate reports with an Xcode project that used the new Folder structure. 

Thanks!
