### PR TITLE
dedupe_profdata: Apply dedupe to profdata coverage as well

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -126,7 +126,11 @@ module Slather
         end
       end
 
-      coverage_files
+      if coverage_files.empty?
+        raise StandardError, "No coverage files found."
+      else
+        dedupe(coverage_files)
+      end
     end
     private :profdata_coverage_files
 


### PR DESCRIPTION
Noticed this strange behaviour of files appearing multiple times when using local SPM packages.

It appears the dedupe function was not used in the newer coverage method.

Should address issues https://github.com/SlatherOrg/slather/issues/348 and https://github.com/SlatherOrg/slather/issues/530 (which is the same issue I encountered)

(Or: is a fix for https://github.com/SlatherOrg/slather/pull/16 no longer working)

Please let me know if I should change anything so the contribution better matches the project's standards. :)